### PR TITLE
fix: make the "diso" snippet more portable

### DIFF
--- a/snippets/global.json
+++ b/snippets/global.json
@@ -1,7 +1,7 @@
 {
   "diso": {
     "prefix": "diso",
-    "body": ["${VIM:strftime(\"%Y-%m-%dT%H:%M:%S\")}"],
+    "body": ["${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}T${CURRENT_HOUR}:${CURRENT_MINUTE}:${CURRENT_SECOND}"],
     "description": "ISO date time stamp"
   }
 }


### PR DESCRIPTION
I noticed the snippet used the vsnip-specific `${VIM:...}` directive, but the VSCode snippet format supports [special variables](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables) for inserting the current date and time. I thought it would be nice to make the snippet compatible with VSCode

Thanks for the cool plugin!
