### PR TITLE
Set global language for global snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "contributes": {
     "snippets": [
       {
-        "language": ["plaintext", "markdown", "tex", "html"],
+        "language": ["plaintext", "markdown", "tex", "html", "global"],
         "path": "./snippets/global.json"
       },
       {


### PR DESCRIPTION
Currently, the global snippets aren't loaded globally for all filetypes in vim-vsnip. Setting the [global filetype](https://github.com/hrsh7th/vim-vsnip/blob/e0b3a6bb28d2418978715942aded4d9a9f2404f5/autoload/vsnip/source.vim#L24) fixes it, though I'm unsure the ramifications on other snippet engines.
