### PR TITLE
[C] Put the opening brack for the block on the same line as the if-clause

### DIFF
--- a/snippets/c.json
+++ b/snippets/c.json
@@ -24,7 +24,7 @@
   },
   "if": {
     "prefix": "if",
-    "body": ["if ($1)", "{", "\t$2", "}"],
+    "body": ["if ($1) {", "\t$2", "}"],
     "description": "Code snippet for if statement"
   },
   "else": {


### PR DESCRIPTION
All other snippets like `for`, `while`, `else if` don't add a newline for the
'{' starting a block. So this just makes it consistent with the rest.