### PR TITLE
Use long form for class snippet for better usability

### DIFF
--- a/snippets/java.json
+++ b/snippets/java.json
@@ -4,8 +4,8 @@
     "body": ["public static void main(String[] args) {", "\t$0", "}"],
     "description": "Public static main method"
   },
-  "cl": {
-    "prefix": "cl",
+  "class": {
+    "prefix": "class",
     "body": ["public class ${TM_FILENAME_BASE} {", "\t$0", "}"],
     "description": "Public class"
   },


### PR DESCRIPTION
Changing the prefix to `class` make both `cl` and `class` work.