### PR TITLE
Ruby: update frozen string literal comment

### DIFF
--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -247,7 +247,7 @@
   },
   "Insert frozen literal string": {
     "prefix": "frozen",
-    "body": "# frozen_string_literal:true$0"
+    "body": "# frozen_string_literal: true$0"
   },
   "Insert require": {
     "prefix": "req",


### PR DESCRIPTION
Adds an extra space to the `frozen` snippet, for code style reasons:
```ruby
# frozen_string_literal: true
```

I think this is a more common way to find the comment in most projects. It's also how Rubocop documentation recommends it: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment.