### PR TITLE
Add R snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ duplicates.
 - Cobol
 - Jekyll(Markdown)
 - Kotlin
+- R(Markdown)
 
 ### Usage
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "path": "./snippets/shell.json"
       },
       {
-        "language": "markdown",
+        "language": ["markdown", "rmd"]},
         "path": "./snippets/markdown.json"
       },
       {
@@ -211,7 +211,7 @@
         "path": "./snippets/twig.json"
       },
       {
-        "language": "r",
+        "language": ["r", "rmd"],
         "path": "./snippets/r.json"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "path": "./snippets/shell.json"
       },
       {
-        "language": ["markdown", "rmd"]},
+        "language": ["markdown", "rmd"],
         "path": "./snippets/markdown.json"
       },
       {

--- a/package.json
+++ b/package.json
@@ -209,6 +209,10 @@
       {
         "language": "twig",
         "path": "./snippets/twig.json"
+      },
+      {
+        "language": "r",
+        "path": "./snippets/r.json"
       }
     ]
   }

--- a/snippets/r.json
+++ b/snippets/r.json
@@ -31,6 +31,7 @@
             "setGeneric(\"${1:generic}\", function(${2:x, ...}) {",
             "    standardGeneric(\"${1:generic}\")",
             "})\n"
+        ]
     },
     "setMethod": {
         "prefix": "sm",

--- a/snippets/r.json
+++ b/snippets/r.json
@@ -1,0 +1,172 @@
+{
+    "library": {
+        "prefix": "lib",
+        "body": [
+            "library(${1:package})"
+        ]
+    },
+    "require": {
+        "prefix": "req",
+        "body": [
+            "require(${1:package})"
+        ]
+    },
+    "source": {
+        "prefix": "src",
+        "body": [
+            "source(\"${1:file.R}\")"
+        ]
+    },
+    "return": {
+        "prefix": "ret",
+        "body": "return(${1:code})"
+    },
+    "matrix": {
+        "prefix": "mat",
+        "body": "matrix(${1:data}, nrow = ${2:rows}, ncol = ${3:cols})"
+    },
+    "setGeneric": {
+        "prefix": "sg",
+        "body": [
+            "setGeneric(\"${1:generic}\", function(${2:x, ...}) {",
+            "    standardGeneric(\"${1:generic}\")",
+            "})\n"
+    },
+    "setMethod": {
+        "prefix": "sm",
+        "body": [
+            "setMethod(\"${1:generic}\", ${2:class}, function(${2:x, ...}) {",
+            "    ${0}",
+            "})\n"
+        ]
+    },
+    "setClass": {
+        "prefix": "sc",
+        "body": [
+            "setClass(\"${1:Class}\", slots = c(${2:name = \"type\"}))\n"
+        ]
+    },
+
+    "if": {
+        "prefix": "if",
+        "body": [
+            "if (${1:condition}) {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "else": {
+        "prefix": "el",
+        "body": [
+            "else {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "else if": {
+        "prefix": "ei",
+        "body": [
+            "else if (${1:condition}) {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "function": {
+        "prefix": "fun",
+        "body": [
+            "${1:name} <- function(${2:variables}) {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "for": {
+        "prefix": "for",
+        "body": [
+            "for (${1:variable} in ${2:vector}) {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "while": {
+        "prefix": "while",
+        "body": [
+            "while (${1:condition}) {",
+            "    ${0}",
+            "}\n"
+        ]
+    },
+    "switch": {
+        "prefix": "switch",
+        "body": [
+            "switch (${1:object},",
+            "    ${2:case} = ${3:action}",
+            ")\n"
+        ]
+    },
+
+    "apply": {
+        "prefix": "apply",
+        "body": "apply(${1:array}, ${2:margin}, ${3:...})"
+    },
+    "lapply": {
+        "prefix": "lapply",
+        "body": "lapply(${1:list}, ${2:function})"
+    },
+    "sapply": {
+        "prefix": "sapply",
+        "body": "sapply(${1:list}, ${2:function})"
+    },
+    "mapply": {
+        "prefix": "mapply",
+        "body": "mapply(${1:function}, ${2:...})"
+    },
+    "tapply": {
+        "prefix": "tapply",
+        "body": "tapply(${1:vector}, ${2:index}, ${3:function})"
+    },
+    "vapply": {
+        "prefix": "vapply",
+        "body": "vapply(${1:list}, ${2:function}, FUN.VALUE = ${3:type}, ${4:...})"
+    },
+    "rapply": {
+        "prefix": "rapply",
+        "body": "rapply(${1:list}, ${2:function})"
+    },
+
+    "timestamp": {
+        "prefix": "ts",
+        "body": "# ${$CURRENT_DAY_NAME_SHORT} ${$CURRENT_MONTH_NAME_SHORT} ${$CURRENT_DATE} ${CURRENT_HOUR}:${CURRENT_MINUTE}:${CURRENT_SECOND} ${CURRENT_YEAR} ------------------------------\n"
+    },
+
+    "shinyapp": {
+        "prefix": "shinyapp",
+        "body": [
+            "library(shiny)",
+            "",
+            "ui <- fluidPage(",
+            "  ${0}",
+            ")",
+            "",
+            "server <- function(input, output, session) {",
+            "  ",
+            "}",
+            "",
+            "shinyApp(ui, server)\n"
+        ]
+    },
+    "shinymod": {
+        "prefix": "shinymod",
+        "body": [
+            "${1:name}_UI <- function(id) {",
+            "  ns <- NS(id)",
+            "  tagList(",
+            "    ${0}",
+            "  )",
+            "}",
+            "",
+            "${1:name} <- function(input, output, session) {",
+            "  ",
+            "}\n"
+        ]
+    }
+}


### PR DESCRIPTION
Add snippet support for R and relatedly R Markdown. Uses the same prefix and template as [RStudio snippets](https://github.com/rstudio/rstudio/blob/main/src/gwt/acesupport/snippets/snippets/r.js)