### PR TITLE
Intuitive prefixes for render and exec in .erb files

### DIFF
--- a/snippets/erb.json
+++ b/snippets/erb.json
@@ -70,14 +70,14 @@
 		"description": "each do"
 	},
 	"render": {
-		"prefix": "pe",
+		"prefix": ["pe", "="],
 		"body": [
 			"<%= $1 %>"
 		],
 		"description": "render block pe"
 	},
 	"exec": {
-		"prefix": "er",
+		"prefix": ["er", "%"],
 		"body": [
 			"<% $1 %>"
 		],


### PR DESCRIPTION
Hi,

I think these two additions are very intuitive to trigger render / exec in .erb files. Especially people coming from UltiSnips will miss these: https://github.com/honza/vim-snippets/blob/master/UltiSnips/eruby.snippets#L30-L40.

Let me know what you think.