### PR TITLE
Made various changes to the react snippets. 

### DIFF
--- a/snippets/javascript/react.json
+++ b/snippets/javascript/react.json
@@ -33,7 +33,7 @@
   },
   "reactFunctionComponent": {
     "prefix": "rfc",
-    "body": "\nconst ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t)\n}\n\nexport default TM_FILENAME_BASE",
+    "body": "\nconst ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t)\n}\n\nexport default ${TM_FILENAME_BASE}",
     "description": "Creates a React function component without PropTypes"
   },
   "reactFunctionComponentWithCustomName": {

--- a/snippets/javascript/react.json
+++ b/snippets/javascript/react.json
@@ -33,12 +33,17 @@
   },
   "reactFunctionComponent": {
     "prefix": "rfc",
-    "body": "import React from 'react'\n\nconst ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t)\n}\n\nexport default ${1}",
+    "body": "\nconst ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t)\n}\n\nexport default TM_FILENAME_BASE",
     "description": "Creates a React function component without PropTypes"
+  },
+  "reactFunctionComponentWithCustomName": {
+    "prefix": "rfcn",
+    "body": "\nconst ${1:functionname} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t)\n}\n\nexport default ${1:functionname}",
+    "description": "Creates a React function component with custom name"
   },
   "reactFunctionComponentWithEmotion": {
     "prefix": "rfce",
-    "body": "import { css } from '@emotion/core'\nimport React from 'react'\n\nexport const ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div css={css``}>\n\t\t\t$0\n\t\t</div>\n\t)\n}",
+    "body": "import { css } from '@emotion/core'\n\nexport const ${TM_FILENAME_BASE} = () => {\n\treturn (\n\t\t<div css={css``}>\n\t\t\t$0\n\t\t</div>\n\t)\n}",
     "description": "Creates a React functional component with emotion"
   },
   "reactStatelessProps": {
@@ -293,11 +298,20 @@
   },
   "useState": {
     "prefix": "us",
-    "body": "const [${0:val}, set${1:setterName}] = useState(${2:defVal})",
+    "body": "const [${1:setterName}, set${1:setterName}] = useState(${2:defVal})$0",
     "description": "use state hook"
   },
   "useEffect": {
     "prefix": "ue",
+    "body": [
+      "useEffect(() => {",
+      "\t$1",
+      "}, [${3:dependencies}])$0"
+    ],
+    "description": "React useEffect() hook"
+  },
+  "useEffect with return": {
+    "prefix": "uer",
     "body": [
       "useEffect(() => {",
       "\t$1",
@@ -306,7 +320,7 @@
       "\t}",
       "}, [${3:dependencies}])$0"
     ],
-    "description": "React useEffect() hook"
+    "description": "React useEffect() hook with return statement"
   },
   "useContext": {
     "prefix": "uc",

--- a/snippets/javascript/react.json
+++ b/snippets/javascript/react.json
@@ -13,7 +13,7 @@
   },
   "reactClassCompoment": {
     "prefix": "rcc",
-    "body": "import React, { Component } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t)\n\t}\n}\n\nexport default ${1}",
+    "body": "import { Component } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t)\n\t}\n}\n\nexport default ${1}",
     "description": "Creates a React component class"
   },
   "reactJustClassCompoment": {
@@ -23,12 +23,12 @@
   },
   "reactClassCompomentPropTypes": {
     "prefix": "rccp",
-    "body": "import React, { Component, PropTypes } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t)\n\t}\n}\n\n${1}.propTypes = {\n\n}\n\nexport default ${1}",
+    "body": "import { Component, PropTypes } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t)\n\t}\n}\n\n${1}.propTypes = {\n\n}\n\nexport default ${1}",
     "description": "Creates a React component class with PropTypes"
   },
   "reactClassCompomentWithMethods": {
     "prefix": "rcfc",
-    "body": "import React, { Component, PropTypes } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\tconstructor(props) {\n\t\tsuper(props)\n\n\t}\n\n\tcomponentWillMount () {\n\n\t}\n\n\tcomponentDidMount () {\n\n\t}\n\n\tcomponentWillReceiveProps (nextProps) {\n\n\t}\n\n\tshouldComponentUpdate (nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate (nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate (prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount () {\n\n\t}\n\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t)\n\t}\n}\n\n${1}.propTypes = {\n\n}\n\nexport default ${1}",
+    "body": "import { Component, PropTypes } from 'react'\n\nclass ${TM_FILENAME_BASE} extends Component {\n\tconstructor(props) {\n\t\tsuper(props)\n\n\t}\n\n\tcomponentWillMount () {\n\n\t}\n\n\tcomponentDidMount () {\n\n\t}\n\n\tcomponentWillReceiveProps (nextProps) {\n\n\t}\n\n\tshouldComponentUpdate (nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate (nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate (prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount () {\n\n\t}\n\n\trender () {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t)\n\t}\n}\n\n${1}.propTypes = {\n\n}\n\nexport default ${1}",
     "description": "Creates a React component class with PropTypes and all lifecycle methods"
   },
   "reactFunctionComponent": {
@@ -48,7 +48,7 @@
   },
   "reactStatelessProps": {
     "prefix": "rfcp",
-    "body": "import React, { PropTypes } from 'react'\n\nconst ${TM_FILENAME_BASE} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t)\n}\n\n${1}.propTypes = {\n\t$0\n}\n\nexport default ${1}",
+    "body": "import { PropTypes } from 'react'\n\nconst ${TM_FILENAME_BASE} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t)\n}\n\n${1}.propTypes = {\n\t$0\n}\n\nexport default ${1}",
     "description": "Creates a React function component with PropTypes"
   },
   "classConstructor": {


### PR DESCRIPTION
1) removed "import React from 'react" as its no longer needed since oct 2020 (React 17)

2) made rfc export the function created aswell (95% of the time you want to export the function you just created)
3) created a react component where you can specify the name in case you want to use it inside another component

4) added the settername to both fields of the useState function (unfortunately I use LuaSnip which does not support regex transformations), so I couldnt test to have the second field capitalized. It should be hard to do but I didnt want to change something I couldnt test myself, should be TODO though
5) Added $0 to the end of the useState to be in line with the other snippets

6) Divided useEffect into two parts, one with the return statement and one without. Most of the time youre not using the return statement, so I made this one into "uer" and kept the one without the return statement as "ue"

EDIT: I just removed "import React from 'react'" in a few more places I missed (in places where multiple things were imported)