### PR TITLE
Update c/cpp snippets for odd behavior

### DIFF
--- a/snippets/c.json
+++ b/snippets/c.json
@@ -84,17 +84,17 @@
   },
   "#inc": {
     "prefix": "#inc",
-    "body": ["#include \"$1\"$0"],
+    "body": ["#include \"$0\""],
     "description": "Code snippet for #include \" \""
   },
   "#inc<": {
     "prefix": "#inc<",
-    "body": ["#include <$1>$0"],
+    "body": ["#include <$0>"],
     "description": "Code snippet for #include < >"
   },
   "#def": {
     "prefix": "def",
-    "body": ["#define $1"],
+    "body": ["#define $0"],
     "description": "Code snippet for #define \" \""
   },
   "Main function template": {

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -198,17 +198,17 @@
   },
   "#inc": {
     "prefix": "#inc",
-    "body": ["#include \"$1\"$0"],
+    "body": ["#include \"$0\""],
     "description": "Code snippet for #include \" \""
   },
   "#inc<": {
     "prefix": "#inc<",
-    "body": ["#include <$1>$0"],
+    "body": ["#include <$0>"],
     "description": "Code snippet for #include < >"
   },
   "#def": {
     "prefix": "def",
-    "body": ["#define $1"],
+    "body": ["#define $0"],
     "description": "Code snippet for #define \" \""
   },
   "Main function template": {


### PR DESCRIPTION
inc and def snippets in c/cpp seems odd.
After I input `inc` and do completion with my completion engine, I got `#include <>` and my cursor is in angle brackets. And then I type `std`, my completion engine suggests `stdio.h` to me and I use it. At this time, my cursor is after `>`. So I can continue my typing with enter. However, in my completion engine will go back to the angle brackets even if I finished include operation. I don't know if it is acceptable to change these snippets.