### PR TITLE
Add eruby to HTML languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
         "language": [
           "html",
           "jade",
-          "pug"
+          "pug",
+          "eruby"
         ],
         "path": "./snippets/html.json"
       },


### PR DESCRIPTION
Embedded Ruby is usually used to embed Ruby in HTML documents. I think it makes sense to make HTML snippets available when in eruby files too.