### PR TITLE
Update: do not close void elements (tag <img>)

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -421,7 +421,7 @@
     },
     "img": {
         "prefix": "img",
-        "body": "<img src=\"$1\" alt=\"$2\"/>$3",
+        "body": "<img src=\"$1\" alt=\"$2\">$3",
         "description": "HTML - Defines an image",
         "scope": "text.html"
     },


### PR DESCRIPTION
Since all void elements are not closed and the wiki says that the img tag is not closed this error should have gone unnoticed