### PR TITLE
Fix vsnip framework example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ specific buffer, but this is going to mess up with syntax highlighting.
 With vim-vsnip:
 
 ```viml
-let g:vsnip_filetypes.rails = ['ruby']
+let g:vsnip_filetypes.ruby = ['rails']
 ```
 
 For more info related to this change see [#88](https://github.com/rafamadriz/friendly-snippets/issues/88)


### PR DESCRIPTION
Hi there! The example in the README for enabling the snippets for a framework in vsnip is incorrect. The `ruby` filetype needs to be extended to include `rails`, not the other way around.

Thanks for making friendly-snippets!