### PR TITLE
fixed rmarkdown yaml header, date code now works

### DIFF
--- a/snippets/rmarkdown.json
+++ b/snippets/rmarkdown.json
@@ -4,7 +4,7 @@
     "body": [
       "---",
       "title: ${1:title}",
-      "date: ${2:`r Sys.Date()`}",
+      "date: ${2:\"`r Sys.Date()`\"}",
       "output: ${4:pdf_document}",
       "---"
     ]


### PR DESCRIPTION
Added a pair of double quotes to the date portion, because the Rmarkdown YAML parser would reject the header in it's current form. This PR fixes it.