### PR TITLE
fix(latex): fix `@{` snippet

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -507,7 +507,7 @@
 	},
 	"{": {
 		"prefix": "@{",
-		"body": "\\left\\{ ${1:${TM_SELECTED_TEXT}} \\right\\\\\\\\}",
+		"body": "\\left\\{ ${1:${TM_SELECTED_TEXT}} \\right\\\\\\}",
 		"description": "left{ ... right}"
 	},
 	"[": {


### PR DESCRIPTION
Current `@{` snippet expands `@{` to `\left\{ \right\\}` in vim-vsnip. Changing `\\\\\\\\` to `\\\\\\` works in both vim-vsnip and LunarVim, so this PR won't make this snippet unusable in LunarVim (#93).

According to vscode (vscode-like snippets should behave same in plugin as that in vscode), four `\` or six `\` should work but eight `\` shouldn't.

Here's the analysis: First we know `}` can be escaped in vscode .

- four `\` case:
  json: `\\\\}` -> string: `\\}` -> snippet: `\}` (The last `}` isn't escaped)
- six `\` case:
  json: `\\\\\\}` -> string: `\\\}` -> snippet: `\}` (The last `}` is escaped)
- eight `\` case:
  json: `\\\\\\\\}` -> string: `\\\\}` -> snippet: `\\}` (The last `}` isn't escaped)

I don't know why [plugin](https://github.com/L3MON4D3/LuaSnip) used by LunarVim has different behaviour with vscode in vscode-link snippets, it might be a bug. To make the snippet works in both vim-vsnip and LunarVim, six `\` should be used.


