### PR TITLE
Fix luasnip error "ipairs"

### DIFF
--- a/snippets/shell.json
+++ b/snippets/shell.json
@@ -24,12 +24,12 @@
   },
   "if": {
     "prefix": "if",
-    "body": "if [[ ${0:condition} ]]; then\n\t${1}\nfi",
+    "body": "if [[ ${1:condition} ]]; then\n\t${0}\nfi",
     "description": "An IF statement."
   },
   "elseif": {
     "prefix": "elseif",
-    "body": "elif [[ ${0:condition} ]]; then\n\t${1}",
+    "body": "elif [[ ${1:condition} ]]; then\n\t${0}",
     "description": "Add an elseif to an if statement."
   },
   "else": {
@@ -39,12 +39,12 @@
   },
   "for_in": {
     "prefix": "for_in",
-    "body": "for ${0:VAR} in $${1:LIST}\ndo\n\techo \"$${0:VAR}\"\ndone\n",
+    "body": "for ${1:VAR} in $${0:LIST}\ndo\n\techo \"$${1:VAR}\"\ndone\n",
     "description": "for loop in list"
   },
   "for_i": {
     "prefix": "for_i",
-    "body": "for ((${0:i} = 0; ${0:i} < ${1:10}; ${0:i}++)); do\n\techo \"$${0:i}\"\ndone\n",
+    "body": "for ((${1:i} = 0; ${1:i} < ${0:10}; ${1:i}++)); do\n\techo \"$${1:i}\"\ndone\n",
     "description": "An index-based iteration for loop."
   },
   "while": {

--- a/snippets/shell.json
+++ b/snippets/shell.json
@@ -71,7 +71,7 @@
   },
   "case": {
     "prefix": "case",
-    "body": "case \"$${0:VAR}\" in\n\t${1:1}) echo 1\n\t;;\n\t${2:2|3}) echo 2 or 3\n\t;;\n\t*) echo default\n\t;;\nesac\n",
+    "body": "case \"$${1:VAR}\" in\n\t${2:1}) echo 1\n\t;;\n\t${3:2|3}) echo 2 or 3\n\t;;\n\t*) echo default\n\t;;\nesac\n",
     "description": [
       "case word in [ [(] pattern [ | pattern ] ... ) list ;; ] ... esac\n",
       "A case command first expands word, and tries to match it against each pattern in turn."


### PR DESCRIPTION
![Peek 2022-03-21 15-51](https://user-images.githubusercontent.com/25432932/159222401-f3adda28-2e51-4842-80e4-9b6baa90de6c.gif)
I use neovim v0.6.1, nvim-packer, nvim-cmp, LuaSnip together. I am sure all are updated to the latest, but i'm having problems from LuaSnip in function `ipairs`. So I did these changes to fix the error. Everything for bash snippets seems to work normal. But I'm not sure if it's right, so please help me check it. Thank you.