### PR TITLE
Add 2 Python Snippets to include return type annotation

### DIFF
--- a/snippets/python/base.json
+++ b/snippets/python/base.json
@@ -60,12 +60,17 @@
     "body": "def ${1:mname}(self, ${2:arg}):\n\t${3:pass}$0",
     "description": "Code snippet for a class method definition."
   },
+  "New method w/ return": {
+    "prefix": "defs",
+    "body": "def ${1:mname}(self, ${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
+    "description": "Code snippet for a class method definition."
+  },
   "New function": {
     "prefix": "def",
     "body": "def ${1:fname}(${2:arg}):\n\t${3:pass}$0",
     "description": "Code snippet for function definition."
   },
-  "New function w/ Return": {
+  "New function w/ return": {
     "prefix": "def",
     "body": "def ${1:fname}(${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
     "description": "Code snippet for function definition."

--- a/snippets/python/base.json
+++ b/snippets/python/base.json
@@ -61,7 +61,7 @@
     "description": "Code snippet for a class method definition."
   },
   "New method w/ return": {
-    "prefix": "deft",
+    "prefix": "defst",
     "body": "def ${1:mname}(self, ${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
     "description": "Code snippet for a class method definition."
   },

--- a/snippets/python/base.json
+++ b/snippets/python/base.json
@@ -65,6 +65,11 @@
     "body": "def ${1:fname}(${2:arg}):\n\t${3:pass}$0",
     "description": "Code snippet for function definition."
   },
+  "New function w/ Return": {
+    "prefix": "def",
+    "body": "def ${1:fname}(${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
+    "description": "Code snippet for function definition."
+  },
   "New async function": {
     "prefix": "adef",
     "body": "async def ${1:fname}(${2:arg}):\n\t${3:pass}$0",

--- a/snippets/python/base.json
+++ b/snippets/python/base.json
@@ -61,7 +61,7 @@
     "description": "Code snippet for a class method definition."
   },
   "New method w/ return": {
-    "prefix": "defs",
+    "prefix": "deft",
     "body": "def ${1:mname}(self, ${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
     "description": "Code snippet for a class method definition."
   },
@@ -71,7 +71,7 @@
     "description": "Code snippet for function definition."
   },
   "New function w/ return": {
-    "prefix": "def",
+    "prefix": "deft",
     "body": "def ${1:fname}(${2:arg}) -> ${3:return_type}:\n\t${4:pass}$0",
     "description": "Code snippet for function definition."
   },


### PR DESCRIPTION
Looking into issue #124, I realized we could just copy the current snippets and append on the return type annotation. 

So now it would look like this when selecting the snippet for the return type: 
![image](https://user-images.githubusercontent.com/56930510/161892998-9b1f8961-867b-466b-9b09-04286cae5826.png)

The one above it in the picture is the original snippet already in the snippet collection. A similar approach was done for the methods snippet.

As always, I am open to input from others :sunglasses: 