### PR TITLE
 Make global snippets available in all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
           "markdown",
           "tex",
           "html",
-          "global"
+          "global",
+          "all"
         ],
         "path": "./snippets/global.json"
       },


### PR DESCRIPTION
This change makes the global snippets available in all files when using LuaSnip.

See https://github.com/L3MON4D3/LuaSnip/issues/419.