### PR TITLE
Fix "datatime" typo and body, and add two more snippets.

### DIFF
--- a/snippets/global.json
+++ b/snippets/global.json
@@ -14,14 +14,24 @@
     "body": ["${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}"],
     "description": "Put the date in (Y-m-D) format"
   },
+  "dateMDY": {
+    "prefix": "dateMDY",
+    "body": ["${CURRENT_MONTH}/${CURRENT_DATE}/${CURRENT_YEAR}"],
+    "description": "Put the date in (m/D/Y) format"
+  },
   "time": {
     "prefix": "time",
     "body": ["${CURRENT_HOUR}:${CURRENT_MINUTE}"],
     "description": "I give you back the time (H:M)"
   },
-  "datatime": {
-    "prefix": "datatime",
-    "body": ["${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}T${CURRENT_HOUR}:${CURRENT_MINUTE}"],
+  "timeHMS": {
+    "prefix": "timeHMS",
+    "body": ["${CURRENT_HOUR}:${CURRENT_MINUTE}:${CURRENT_SECOND}"],
+    "description": "I give you back the time (H:M:S)"
+  },
+  "datetime": {
+    "prefix": "datetime",
+    "body": ["${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE} ${CURRENT_HOUR}:${CURRENT_MINUTE}"],
     "description": "I give you back the time and date (Y-m-d H:M)"
   },
   "Lorem Ipsum Sentence": {


### PR DESCRIPTION
Assuming https://github.com/honza/vim-snippets was used as the inspiration for this repo, I change 'datatime' to 'datetime' and removed the 'T' from its body, matching the definition in the original.

I also added an new date snippet for the format common in the United States, as well as a time snippet with seconds.