### PR TITLE
fix: Corrects path to es7 snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
           "javascriptreact",
           "typescriptreact"
         ],
-        "path": "./snippets/javascript/vscode-react.json"
+        "path": "./snippets/javascript/react-es7.json"
       },
       {
         "language": "svelte",


### PR DESCRIPTION
- Corrects the path used in `package.json` for the es7 snippets added in #164  and should resolve issue #171 