### PR TITLE
Change order for do-while snippet

### DIFF
--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -19,7 +19,7 @@
   },
   "do": {
     "prefix": "do",
-    "body": ["do", "{", "\t$1", "} while($2);"],
+    "body": ["do", "{", "\t$0", "} while($1);"],
     "description": "Code snippet for do...while loop"
   },
   "while": {


### PR DESCRIPTION
I think that doing the while condition before the do body is a better way of setting the snippet.