### PR TITLE
Elixir: Align prefixes with inserted code

### DIFF
--- a/snippets/elixir.json
+++ b/snippets/elixir.json
@@ -175,7 +175,7 @@
     ]
   },
   "des": {
-    "prefix": "test",
+    "prefix": "desc",
     "body": [
       "describe \"${1:test group subject}\" do",
       "  $0",
@@ -206,7 +206,7 @@
     "body": "|> Enum.filter($0)"
   },
   "pipe into reduce": {
-    "prefix": ">f",
+    "prefix": ">r",
     "body": "|> Enum.reduce(${1:acc}, fn ${2}, ${3:acc} -> $0 end)"
   },
   "word list": {
@@ -214,7 +214,7 @@
     "body": "~w($0)"
   },
   "atom list": {
-    "prefix": "wl",
+    "prefix": "al",
     "body": "~w($0)a"
   }
 }


### PR DESCRIPTION
Some of the prefixes inside the elixir file seemed a little odd, so I updated them to more closely match the thing they are trying to achieve, i.e. creating an atom list now has an `al` prefix instead of sharing `wl` with the word list.

Feel free to just close this, if there is some deeper meaning behind this.