### PR TITLE
Improve Fortran snippets

### DIFF
--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -1,520 +1,520 @@
 {
-	"all": {
-		"prefix": "all",
-		"body": "all(${1:mask}${2:, dim=${3:1}})",
-		"description": "all",
-		"scope": "source.fortran"
-	},
-	"alloc": {
-		"prefix": "alloc",
-		"body": [
-			"allocate(${1:array}, stat=${2:err})",
-			"if ($2 /= 0) print *, \"$1: Allocation request denied\"",
-			"",
-			"if (allocated($1)) deallocate($1, stat=$2)",
-			"if ($2 /= 0) print *, \"$1: Deallocation request denied\""
-		],
-		"description": "Allocate and Deallocate array",
-		"scope": "source.fortran"
-	},
-	"al": {
-		"body": [
-			"allocate(${1:array}, stat=${2:err})",
-			"if ($2 /= 0) print *, \"$1: Allocation request denied\""
-		],
-		"prefix": "al",
-		"description": "Allocate Array"
-	},
-	"and": {
-		"prefix": "and",
-		"body": ".and.",
-		"description": "And",
-		"scope": "source.fortran"
-	},
-	"any": {
-		"prefix": "any",
-		"body": "any(${1:mask}${2:, dim=${3:1}})",
-		"description": "any",
-		"scope": "source.fortran"
-	},
-	"case": {
-		"prefix": "case",
-		"body": "case ${1:default}\n\t$0",
-		"description": "case",
-		"scope": "source.fortran"
-	},
-	"char": {
-		"prefix": "char",
-		"body": "character(len=$1${2:, kind=$3})${4:, ${5:attributes}} :: ${6:name}",
-		"description": "Character",
-		"scope": "source.fortran"
-	},
-	"close": {
-		"prefix": "close",
-		"body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\nif ( $2 /= 0 ) stop \"Error closing file unit $1\"\n",
-		"description": "Close File",
-		"scope": "source.fortran"
-	},
-	"count": {
-		"prefix": "count",
-		"body": "count(${1:mask}${2:, dim=${3:1}})",
-		"description": "count",
-		"scope": "source.fortran"
-	},
-	"typ": {
-		"prefix": "typ",
-		"body": "type(${1:type name})${2:, ${3:attributes}} :: ${4:name}",
-		"description": "Custom Type",
-		"scope": "source.fortran"
-	},
-	"cy": {
-		"prefix": "cy",
-		"body": "cycle",
-		"description": "cycle",
-		"scope": "source.fortran"
-	},
-	"data": {
-		"prefix": "data",
-		"body": "data ${1:variable} / ${2:data} /",
-		"description": "data",
-		"scope": "source.fortran"
-	},
-	"deal": {
-		"prefix": "deal",
-		"body": "if (allocated($1)) deallocate(${1:array}, stat=${2:err})\nif ($2 /= 0) print *, \"$1: Deallocation request denied$0\"",
-		"description": "Deallocate Array",
-		"scope": "source.fortran"
-	},
-	"dow": {
-		"prefix": "dow",
-		"body": "do while ( ${1:condition} )\n\t$0\nend do",
-		"description": "do while",
-		"scope": "source.fortran"
-	},
-	"do": {
-		"prefix": "do",
-		"body": "do${1: ${2:i} = ${3:1}, ${4:100}, ${5:1}}\n\t$0\nend do",
-		"description": "do",
-		"scope": "source.fortran"
-	},
-	"dot": {
-		"prefix": "dot",
-		"body": "dot_product($1,$2)",
-		"description": "Dot Product of Vectors",
-		"scope": "source.fortran"
-	},
-	"elif": {
-		"prefix": "elif",
-		"body": "elseif ( ${1:condition} ) then\n\t",
-		"description": "elseif",
-		"scope": "source.fortran"
-	},
-	"eq": {
-		"prefix": "eq",
-		"body": ".eq.",
-		"description": "Equal",
-		"scope": "source.fortran"
-	},
-	"eqv": {
-		"prefix": "eqv",
-		"body": ".eqv.",
-		"description": "Equality",
-		"scope": "source.fortran"
-	},
-	"for": {
-		"prefix": "for",
-		"body": "forall (${1:i=1:100}${2:, mask})\n\t$0\nend forall",
-		"description": "forall",
-		"scope": "source.fortran.modern"
-	},
-	"fun": {
-		"prefix": "fun",
-		"body": [
-			"function ${1:name}(${2:input}) result(${3:output})",
-			"\t${4:argument type}, intent(${5:inout}) :: $2",
-			"\t${6:function type} :: $3",
-			"\t$0",
-			"end function $1"
-		],
-		"description": "function",
-		"scope": "source.fortran"
-	},
-	"ge": {
-		"prefix": "ge",
-		"body": ".ge.",
-		"description": "Greater or Equal",
-		"scope": "source.fortran"
-	},
-	"gt": {
-		"prefix": "gt",
-		"body": ".gt.",
-		"description": "Greater Than",
-		"scope": "source.fortran"
-	},
-	"if": {
-		"prefix": "if",
-		"body": "if ( ${1:condition} ) ",
-		"description": "if (single line)",
-		"scope": "source.fortran"
-	},
-	"if1": {
-		"prefix": "if",
-		"body": "if ( ${1:condition} ) then\n\t$0\nend if",
-		"description": "if",
-		"scope": "source.fortran"
-	},
-	"imp": {
-		"prefix": "imp",
-		"body": "implicit none\n",
-		"description": "implicit none",
-		"scope": "source.fortran"
-	},
-	"ido": {
-		"prefix": "ido",
-		"body": "(${1:i}, $1 = ${2:1}, ${3:100}, ${4:1})$0",
-		"description": "Implied do",
-		"scope": "source.fortran"
-	},
-	"maxloc": {
-		"prefix": "maxloc",
-		"body": "maxloc(${1:source}${2:, mask=${3:($1>0)}})",
-		"description": "Index of Maximum",
-		"scope": "source.fortran"
-	},
-	"minloc": {
-		"prefix": "minloc",
-		"body": "minloc(${1:source}${2:, mask=${3:$1>0}})",
-		"description": "Index of Minimum",
-		"scope": "source.fortran"
-	},
-	"open": {
-		"prefix": "open",
-		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
-		"description": "Input File",
-		"scope": "source.fortran"
-	},
-	"inq": {
-		"prefix": "inq",
-		"body": "inquire(file=${1:filename}, opened=${2:ioopen}, exists=${3:ioexist}, number=${4:iounit})",
-		"description": "Inquire (by Filename)",
-		"scope": "source.fortran"
-	},
-	"inq1": {
-		"prefix": "inq",
-		"body": "inquire(unit=${1:iounit}, opened=${2:ioopen}, name=${3:filename}, action=${4:ioaction})",
-		"description": "Inquire (by Unit)",
-		"scope": "source.fortran"
-	},
-	"int": {
-		"prefix": "int",
-		"body": "integer${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-		"description": "Integer",
-		"scope": "source.fortran"
-	},
-	"interf": {
-		"prefix": "interf",
-		"body": "interface ${1:name}\n\t$0\nend interface $1",
-		"description": "interface",
-		"scope": "source.fortran"
-	},
-	"le": {
-		"prefix": "le",
-		"body": ".le.",
-		"description": "Less or Equal",
-		"scope": "source.fortran"
-	},
-	"lt": {
-		"prefix": "lt",
-		"body": ".lt.",
-		"description": "Less Than",
-		"scope": "source.fortran"
-	},
-	"log": {
-		"prefix": "log",
-		"body": "logical${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-		"description": "Logical",
-		"scope": "source.fortran"
-	},
-	"lbound": {
-		"prefix": "lbound",
-		"body": "lbound(${1:source}${2:, dim=${3:1}})",
-		"description": "Lower Bound",
-		"scope": "source.fortran"
-	},
-	"mat": {
-		"prefix": "mat",
-		"body": "matmul($1,$2)",
-		"description": "Matrix Multiplication",
-		"scope": "source.fortran"
-	},
-	"max": {
-		"prefix": "max",
-		"body": "max($1, $2${, $3:...})$0",
-		"description": "max",
-		"scope": "source.fortran"
-	},
-	"maxval": {
-		"prefix": "maxval",
-		"body": "maxval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-		"description": "Maximum Value",
-		"scope": "source.fortran"
-	},
-	"merge": {
-		"prefix": "merge",
-		"body": "merge(${1:source}, ${2:alternative}, mask=(${2:$1>0}))",
-		"description": "merge",
-		"scope": "source.fortran"
-	},
-	"min": {
-		"prefix": "min",
-		"body": "min($1, $2${, $3:...})$0",
-		"description": "min",
-		"scope": "source.fortran"
-	},
-	"minval": {
-		"prefix": "minval",
-		"body": "minval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-		"description": "Minimum Value",
-		"scope": "source.fortran"
-	},
-	"mp": {
-		"prefix": "mp",
-		"body": "module procedure ${0:name}",
-		"description": "module procedure",
-		"scope": "source.fortran"
-	},
-	"mod": {
-		"prefix": "mod",
-		"body": "module ${1:name}\n\n\timplicit none\n\t$0\n\nend module $1\n",
-		"description": "module",
-		"scope": "source.fortran"
-	},
-	"neqv": {
-		"prefix": "neqv",
-		"body": ".neqv.",
-		"description": "Non-Equality",
-		"scope": "source.fortran"
-	},
-	"not": {
-		"prefix": "not",
-		"body": ".not.",
-		"description": "Not",
-		"scope": "source.fortran"
-	},
-	"open1": {
-		"prefix": "open",
-		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
-		"description": "Open File",
-		"scope": "source.fortran"
-	},
-	"or": {
-		"prefix": "or",
-		"body": ".or.",
-		"description": "Or",
-		"scope": "source.fortran"
-	},
-	"open2": {
-		"prefix": "open",
-		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
-		"description": "Output File",
-		"scope": "source.fortran"
-	},
-	"pack": {
-		"prefix": "pack",
-		"body": "pack(${1:array}, mask=(${2:$1>0})${3:, vector=${4:destination vector}})",
-		"description": "pack",
-		"scope": "source.fortran"
-	},
-	"pr": {
-		"prefix": "pr",
-		"body": "print*, ",
-		"description": "Quick Print",
-		"scope": "source.fortran"
-	},
-	"prod": {
-		"prefix": "prod",
-		"body": "product(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-		"description": "Product of Elements",
-		"scope": "source.fortran"
-	},
-	"prog": {
-		"prefix": "prog",
-		"body": "program ${1:name}\n\n\timplicit none\n\t$0\n\nend program $1\n",
-		"description": "program",
-		"scope": "source.fortran"
-	},
-	"c": {
-		"prefix": "c",
-		"body": "character(len=*) :: ",
-		"description": "Quick Character",
-		"scope": "source.fortran"
-	},
-	"t": {
-		"prefix": "t",
-		"body": "type(${1:type name}) :: ",
-		"description": "Quick Custom Type",
-		"scope": "source.fortran"
-	},
-	"i": {
-		"prefix": "i",
-		"body": "integer :: ",
-		"description": "Quick Integer",
-		"scope": "source.fortran"
-	},
-	"l": {
-		"prefix": "l",
-		"body": "logical :: ",
-		"description": "Quick Logical",
-		"scope": "source.fortran"
-	},
-	"op": {
-		"prefix": "op",
-		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
-		"description": "Quick Open",
-		"scope": "source.fortran"
-	},
-	"re": {
-		"prefix": "re",
-		"body": "read*, ",
-		"description": "Quick Read",
-		"scope": "source.fortran"
-	},
-	"r": {
-		"prefix": "r",
-		"body": "real :: ",
-		"description": "Quick Real",
-		"scope": "source.fortran"
-	},
-	"wr": {
-		"prefix": "wr",
-		"body": "write(unit=${1:iounit}, fmt=*) ${0:variables}\n",
-		"description": "Quick Write",
-		"scope": "source.fortran"
-	},
-	"rn": {
-		"prefix": "rn",
-		"body": "call random_number($0)",
-		"description": "Random Number",
-		"scope": "source.fortran"
-	},
-	"rs": {
-		"prefix": "rs",
-		"body": "call random_seed(${1:size=${2:<int>}}${3:put=(/$4/)})",
-		"description": "Random Seed",
-		"scope": "source.fortran"
-	},
-	"read": {
-		"prefix": "read",
-		"body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
-		"description": "Read (Non Advancing Mode)",
-		"scope": "source.fortran"
-	},
-	"read1": {
-		"prefix": "read",
-		"body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
-		"description": "Read",
-		"scope": "source.fortran"
-	},
-	"rea": {
-		"prefix": "rea",
-		"body": "real${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-		"description": "Real",
-		"scope": "source.fortran"
-	},
-	"resh": {
-		"prefix": "resh",
-		"body": "reshape(${1:source}${2:, shape=(/$3/)}${4:, pad=(/$5/)}${6:, order=(/${7:2,1}/)})",
-		"description": "reshape",
-		"scope": "source.fortran"
-	},
-	"open3": {
-		"prefix": "open",
-		"body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\nif ( $3 /= 0 ) stop \"Error opening scratch file on unit $1\"\n",
-		"description": "Scratch File",
-		"scope": "source.fortran"
-	},
-	"sel": {
-		"prefix": "sel",
-		"body": "select case ($1:variable)\n\tcase ($2:values)\n\t\t$0\nend select",
-		"description": "select case",
-		"scope": "source.fortran"
-	},
-	"size": {
-		"prefix": "size",
-		"body": "size(${1:source}${2:, dim=${3:1}})",
-		"description": "Size",
-		"scope": "source.fortran"
-	},
-	"spread": {
-		"prefix": "spread",
-		"body": "spread(${1:source}, dim=${2:1}, ncopies=$3)",
-		"description": "spread",
-		"scope": "source.fortran"
-	},
-	"stop": {
-		"prefix": "stop",
-		"body": "stop \"${1:message}\"",
-		"description": "stop",
-		"scope": "source.fortran"
-	},
-	"sub": {
-		"prefix": "sub",
-		"body": "subroutine ${1:name}(${2:input})\n\t${3:argument type}, intent(${4:inout}) :: ${2/\\w+\\((.*)\\)|.*/$2/}\n\t$0\nend subroutine ${1/(\\w+).*/$1/}",
-		"description": "subroutine",
-		"scope": "source.fortran"
-	},
-	"sum": {
-		"prefix": "sum",
-		"body": "sum(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-		"description": "Sum of Elements",
-		"scope": "source.fortran"
-	},
-	"type": {
-		"prefix": "type",
-		"body": "type ${1:type name}\n\t$0\nend type $1",
-		"description": "Type Definition",
-		"scope": "source.fortran"
-	},
-	"unpack": {
-		"prefix": "unpack",
-		"body": "unpack(${1:vector}, mask=(${2:$1>0}), field=${3:destination array})",
-		"description": "unpack",
-		"scope": "source.fortran"
-	},
-	"ubound": {
-		"prefix": "ubound",
-		"body": "ubound(${1:source}${2:, dim=${3:1}})",
-		"description": "Upper Bound",
-		"scope": "source.fortran"
-	},
-	"wh": {
-		"prefix": "wh",
-		"body": "where ( $1 ${2:==} $3 ) ",
-		"description": "where (single line)",
-		"scope": "source.fortran"
-	},
-	"whe": {
-		"prefix": "whe",
-		"body": "where ( $1 ${2:==} $3 )\n\t$0\nend where",
-		"description": "where",
-		"scope": "source.fortran"
-	},
-	"write": {
-		"prefix": "write",
-		"body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\nif ( $3 /= 0 ) stop \"Write error in file unit $1\"\n",
-		"description": "Write",
-		"scope": "source.fortran"
-	},
-	"fa": {
-		"prefix": "fa",
-		"body": ".false.",
-		"description": ".false.",
-		"scope": "source.fortran"
-	},
-	"tr": {
-		"prefix": "tr",
-		"body": ".true.",
-		"description": ".true.",
-		"scope": "source.fortran"
-	}
+  "all": {
+    "prefix": "all",
+    "body": "all(${1:mask}${2:, dim=${3:1}})",
+    "description": "all",
+    "scope": "source.fortran"
+  },
+  "alloc": {
+    "prefix": "alloc",
+    "body": [
+      "allocate(${1:array}, stat=${2:err})",
+      "if ($2 /= 0) print *, \"$1: Allocation request denied\"",
+      "",
+      "if (allocated($1)) deallocate($1, stat=$2)",
+      "if ($2 /= 0) print *, \"$1: Deallocation request denied\""
+    ],
+    "description": "Allocate and Deallocate array",
+    "scope": "source.fortran"
+  },
+  "al": {
+    "body": [
+      "allocate(${1:array}, stat=${2:err})",
+      "if ($2 /= 0) print *, \"$1: Allocation request denied\""
+    ],
+    "prefix": "al",
+    "description": "Allocate Array"
+  },
+  "and": {
+    "prefix": "and",
+    "body": ".and.",
+    "description": "And",
+    "scope": "source.fortran"
+  },
+  "any": {
+    "prefix": "any",
+    "body": "any(${1:mask}${2:, dim=${3:1}})",
+    "description": "any",
+    "scope": "source.fortran"
+  },
+  "case": {
+    "prefix": "case",
+    "body": "case ${1:default}\n\t$0",
+    "description": "case",
+    "scope": "source.fortran"
+  },
+  "char": {
+    "prefix": "char",
+    "body": "character(len=$1${2:, kind=$3})${4:, ${5:attributes}} :: ${6:name}",
+    "description": "Character",
+    "scope": "source.fortran"
+  },
+  "close": {
+    "prefix": "close",
+    "body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\nif ( $2 /= 0 ) stop \"Error closing file unit $1\"\n",
+    "description": "Close File",
+    "scope": "source.fortran"
+  },
+  "count": {
+    "prefix": "count",
+    "body": "count(${1:mask}${2:, dim=${3:1}})",
+    "description": "count",
+    "scope": "source.fortran"
+  },
+  "typ": {
+    "prefix": "typ",
+    "body": "type(${1:type name})${2:, ${3:attributes}} :: ${4:name}",
+    "description": "Custom Type",
+    "scope": "source.fortran"
+  },
+  "cy": {
+    "prefix": "cy",
+    "body": "cycle",
+    "description": "cycle",
+    "scope": "source.fortran"
+  },
+  "data": {
+    "prefix": "data",
+    "body": "data ${1:variable} / ${2:data} /",
+    "description": "data",
+    "scope": "source.fortran"
+  },
+  "deal": {
+    "prefix": "deal",
+    "body": "if (allocated($1)) deallocate(${1:array}, stat=${2:err})\nif ($2 /= 0) print *, \"$1: Deallocation request denied$0\"",
+    "description": "Deallocate Array",
+    "scope": "source.fortran"
+  },
+  "dow": {
+    "prefix": "dow",
+    "body": "do while ( ${1:condition} )\n\t$0\nend do",
+    "description": "do while",
+    "scope": "source.fortran"
+  },
+  "do": {
+    "prefix": "do",
+    "body": "do${1: ${2:i} = ${3:1}, ${4:100}, ${5:1}}\n\t$0\nend do",
+    "description": "do",
+    "scope": "source.fortran"
+  },
+  "dot": {
+    "prefix": "dot",
+    "body": "dot_product($1,$2)",
+    "description": "Dot Product of Vectors",
+    "scope": "source.fortran"
+  },
+  "elif": {
+    "prefix": "elif",
+    "body": "elseif ( ${1:condition} ) then\n\t",
+    "description": "elseif",
+    "scope": "source.fortran"
+  },
+  "eq": {
+    "prefix": "eq",
+    "body": ".eq.",
+    "description": "Equal",
+    "scope": "source.fortran"
+  },
+  "eqv": {
+    "prefix": "eqv",
+    "body": ".eqv.",
+    "description": "Equality",
+    "scope": "source.fortran"
+  },
+  "for": {
+    "prefix": "for",
+    "body": "forall (${1:i=1:100}${2:, mask})\n\t$0\nend forall",
+    "description": "forall",
+    "scope": "source.fortran.modern"
+  },
+  "fun": {
+    "prefix": "fun",
+    "body": [
+      "function ${1:name}(${2:input}) result(${3:output})",
+      "\t${4:argument type}, intent(${5:inout}) :: $2",
+      "\t${6:function type} :: $3",
+      "\t$0",
+      "end function $1"
+    ],
+    "description": "function",
+    "scope": "source.fortran"
+  },
+  "ge": {
+    "prefix": "ge",
+    "body": ".ge.",
+    "description": "Greater or Equal",
+    "scope": "source.fortran"
+  },
+  "gt": {
+    "prefix": "gt",
+    "body": ".gt.",
+    "description": "Greater Than",
+    "scope": "source.fortran"
+  },
+  "if": {
+    "prefix": "if",
+    "body": "if ( ${1:condition} ) ",
+    "description": "if (single line)",
+    "scope": "source.fortran"
+  },
+  "if1": {
+    "prefix": "if",
+    "body": "if ( ${1:condition} ) then\n\t$0\nend if",
+    "description": "if",
+    "scope": "source.fortran"
+  },
+  "imp": {
+    "prefix": "imp",
+    "body": "implicit none\n",
+    "description": "implicit none",
+    "scope": "source.fortran"
+  },
+  "ido": {
+    "prefix": "ido",
+    "body": "(${1:i}, $1 = ${2:1}, ${3:100}, ${4:1})$0",
+    "description": "Implied do",
+    "scope": "source.fortran"
+  },
+  "maxloc": {
+    "prefix": "maxloc",
+    "body": "maxloc(${1:source}${2:, mask=${3:($1>0)}})",
+    "description": "Index of Maximum",
+    "scope": "source.fortran"
+  },
+  "minloc": {
+    "prefix": "minloc",
+    "body": "minloc(${1:source}${2:, mask=${3:$1>0}})",
+    "description": "Index of Minimum",
+    "scope": "source.fortran"
+  },
+  "open": {
+    "prefix": "open",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+    "description": "Input File",
+    "scope": "source.fortran"
+  },
+  "inq": {
+    "prefix": "inq",
+    "body": "inquire(file=${1:filename}, opened=${2:ioopen}, exists=${3:ioexist}, number=${4:iounit})",
+    "description": "Inquire (by Filename)",
+    "scope": "source.fortran"
+  },
+  "inq1": {
+    "prefix": "inq",
+    "body": "inquire(unit=${1:iounit}, opened=${2:ioopen}, name=${3:filename}, action=${4:ioaction})",
+    "description": "Inquire (by Unit)",
+    "scope": "source.fortran"
+  },
+  "int": {
+    "prefix": "int",
+    "body": "integer${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+    "description": "Integer",
+    "scope": "source.fortran"
+  },
+  "interf": {
+    "prefix": "interf",
+    "body": "interface ${1:name}\n\t$0\nend interface $1",
+    "description": "interface",
+    "scope": "source.fortran"
+  },
+  "le": {
+    "prefix": "le",
+    "body": ".le.",
+    "description": "Less or Equal",
+    "scope": "source.fortran"
+  },
+  "lt": {
+    "prefix": "lt",
+    "body": ".lt.",
+    "description": "Less Than",
+    "scope": "source.fortran"
+  },
+  "log": {
+    "prefix": "log",
+    "body": "logical${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+    "description": "Logical",
+    "scope": "source.fortran"
+  },
+  "lbound": {
+    "prefix": "lbound",
+    "body": "lbound(${1:source}${2:, dim=${3:1}})",
+    "description": "Lower Bound",
+    "scope": "source.fortran"
+  },
+  "mat": {
+    "prefix": "mat",
+    "body": "matmul($1,$2)",
+    "description": "Matrix Multiplication",
+    "scope": "source.fortran"
+  },
+  "max": {
+    "prefix": "max",
+    "body": "max($1, $2${, $3:...})$0",
+    "description": "max",
+    "scope": "source.fortran"
+  },
+  "maxval": {
+    "prefix": "maxval",
+    "body": "maxval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+    "description": "Maximum Value",
+    "scope": "source.fortran"
+  },
+  "merge": {
+    "prefix": "merge",
+    "body": "merge(${1:source}, ${2:alternative}, mask=(${2:$1>0}))",
+    "description": "merge",
+    "scope": "source.fortran"
+  },
+  "min": {
+    "prefix": "min",
+    "body": "min($1, $2${, $3:...})$0",
+    "description": "min",
+    "scope": "source.fortran"
+  },
+  "minval": {
+    "prefix": "minval",
+    "body": "minval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+    "description": "Minimum Value",
+    "scope": "source.fortran"
+  },
+  "mp": {
+    "prefix": "mp",
+    "body": "module procedure ${0:name}",
+    "description": "module procedure",
+    "scope": "source.fortran"
+  },
+  "mod": {
+    "prefix": "mod",
+    "body": "module ${1:name}\n\n\timplicit none\n\t$0\n\nend module $1\n",
+    "description": "module",
+    "scope": "source.fortran"
+  },
+  "neqv": {
+    "prefix": "neqv",
+    "body": ".neqv.",
+    "description": "Non-Equality",
+    "scope": "source.fortran"
+  },
+  "not": {
+    "prefix": "not",
+    "body": ".not.",
+    "description": "Not",
+    "scope": "source.fortran"
+  },
+  "open1": {
+    "prefix": "open",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+    "description": "Open File",
+    "scope": "source.fortran"
+  },
+  "or": {
+    "prefix": "or",
+    "body": ".or.",
+    "description": "Or",
+    "scope": "source.fortran"
+  },
+  "open2": {
+    "prefix": "open",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+    "description": "Output File",
+    "scope": "source.fortran"
+  },
+  "pack": {
+    "prefix": "pack",
+    "body": "pack(${1:array}, mask=(${2:$1>0})${3:, vector=${4:destination vector}})",
+    "description": "pack",
+    "scope": "source.fortran"
+  },
+  "pr": {
+    "prefix": "pr",
+    "body": "print*, ",
+    "description": "Quick Print",
+    "scope": "source.fortran"
+  },
+  "prod": {
+    "prefix": "prod",
+    "body": "product(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+    "description": "Product of Elements",
+    "scope": "source.fortran"
+  },
+  "prog": {
+    "prefix": "prog",
+    "body": "program ${1:name}\n\n\timplicit none\n\t$0\n\nend program $1\n",
+    "description": "program",
+    "scope": "source.fortran"
+  },
+  "c": {
+    "prefix": "c",
+    "body": "character(len=*) :: ",
+    "description": "Quick Character",
+    "scope": "source.fortran"
+  },
+  "t": {
+    "prefix": "t",
+    "body": "type(${1:type name}) :: ",
+    "description": "Quick Custom Type",
+    "scope": "source.fortran"
+  },
+  "i": {
+    "prefix": "i",
+    "body": "integer :: ",
+    "description": "Quick Integer",
+    "scope": "source.fortran"
+  },
+  "l": {
+    "prefix": "l",
+    "body": "logical :: ",
+    "description": "Quick Logical",
+    "scope": "source.fortran"
+  },
+  "op": {
+    "prefix": "op",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+    "description": "Quick Open",
+    "scope": "source.fortran"
+  },
+  "re": {
+    "prefix": "re",
+    "body": "read*, ",
+    "description": "Quick Read",
+    "scope": "source.fortran"
+  },
+  "r": {
+    "prefix": "r",
+    "body": "real :: ",
+    "description": "Quick Real",
+    "scope": "source.fortran"
+  },
+  "wr": {
+    "prefix": "wr",
+    "body": "write(unit=${1:iounit}, fmt=*) ${0:variables}\n",
+    "description": "Quick Write",
+    "scope": "source.fortran"
+  },
+  "rn": {
+    "prefix": "rn",
+    "body": "call random_number($0)",
+    "description": "Random Number",
+    "scope": "source.fortran"
+  },
+  "rs": {
+    "prefix": "rs",
+    "body": "call random_seed(${1:size=${2:<int>}}${3:put=(/$4/)})",
+    "description": "Random Seed",
+    "scope": "source.fortran"
+  },
+  "read": {
+    "prefix": "read",
+    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+    "description": "Read (Non Advancing Mode)",
+    "scope": "source.fortran"
+  },
+  "read1": {
+    "prefix": "read",
+    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+    "description": "Read",
+    "scope": "source.fortran"
+  },
+  "rea": {
+    "prefix": "rea",
+    "body": "real${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+    "description": "Real",
+    "scope": "source.fortran"
+  },
+  "resh": {
+    "prefix": "resh",
+    "body": "reshape(${1:source}${2:, shape=(/$3/)}${4:, pad=(/$5/)}${6:, order=(/${7:2,1}/)})",
+    "description": "reshape",
+    "scope": "source.fortran"
+  },
+  "open3": {
+    "prefix": "open",
+    "body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\nif ( $3 /= 0 ) stop \"Error opening scratch file on unit $1\"\n",
+    "description": "Scratch File",
+    "scope": "source.fortran"
+  },
+  "sel": {
+    "prefix": "sel",
+    "body": "select case ($1:variable)\n\tcase ($2:values)\n\t\t$0\nend select",
+    "description": "select case",
+    "scope": "source.fortran"
+  },
+  "size": {
+    "prefix": "size",
+    "body": "size(${1:source}${2:, dim=${3:1}})",
+    "description": "Size",
+    "scope": "source.fortran"
+  },
+  "spread": {
+    "prefix": "spread",
+    "body": "spread(${1:source}, dim=${2:1}, ncopies=$3)",
+    "description": "spread",
+    "scope": "source.fortran"
+  },
+  "stop": {
+    "prefix": "stop",
+    "body": "stop \"${1:message}\"",
+    "description": "stop",
+    "scope": "source.fortran"
+  },
+  "sub": {
+    "prefix": "sub",
+    "body": "subroutine ${1:name}(${2:input})\n\t${3:argument type}, intent(${4:inout}) :: ${2/\\w+\\((.*)\\)|.*/$2/}\n\t$0\nend subroutine ${1/(\\w+).*/$1/}",
+    "description": "subroutine",
+    "scope": "source.fortran"
+  },
+  "sum": {
+    "prefix": "sum",
+    "body": "sum(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+    "description": "Sum of Elements",
+    "scope": "source.fortran"
+  },
+  "type": {
+    "prefix": "type",
+    "body": "type ${1:type name}\n\t$0\nend type $1",
+    "description": "Type Definition",
+    "scope": "source.fortran"
+  },
+  "unpack": {
+    "prefix": "unpack",
+    "body": "unpack(${1:vector}, mask=(${2:$1>0}), field=${3:destination array})",
+    "description": "unpack",
+    "scope": "source.fortran"
+  },
+  "ubound": {
+    "prefix": "ubound",
+    "body": "ubound(${1:source}${2:, dim=${3:1}})",
+    "description": "Upper Bound",
+    "scope": "source.fortran"
+  },
+  "wh": {
+    "prefix": "wh",
+    "body": "where ( $1 ${2:==} $3 ) ",
+    "description": "where (single line)",
+    "scope": "source.fortran"
+  },
+  "whe": {
+    "prefix": "whe",
+    "body": "where ( $1 ${2:==} $3 )\n\t$0\nend where",
+    "description": "where",
+    "scope": "source.fortran"
+  },
+  "write": {
+    "prefix": "write",
+    "body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\nif ( $3 /= 0 ) stop \"Write error in file unit $1\"\n",
+    "description": "Write",
+    "scope": "source.fortran"
+  },
+  "fa": {
+    "prefix": "fa",
+    "body": ".false.",
+    "description": ".false.",
+    "scope": "source.fortran"
+  },
+  "tr": {
+    "prefix": "tr",
+    "body": ".true.",
+    "description": ".true.",
+    "scope": "source.fortran"
+  }
 }

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -213,7 +213,7 @@
 	},
 	"interf": {
 		"prefix": "interf",
-		"body": "interface ${1:name}\n\t$0\nend interface ! $1",
+		"body": "interface ${1:name}\n\t$0\nend interface $1",
 		"description": "interface",
 		"scope": "source.fortran"
 	},

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -505,8 +505,8 @@
 		"description": "Write",
 		"scope": "source.fortran"
 	},
-	"fal": {
-		"prefix": "fal",
+	"fa": {
+		"prefix": "fa",
 		"body": ".false.",
 		"description": ".false.",
 		"scope": "source.fortran"

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -505,16 +505,16 @@
 		"description": "Write",
 		"scope": "source.fortran"
 	},
-	"F": {
-		"prefix": "F",
-		"body": ".FALSE.",
-		"description": ".FALSE.",
+	"fal": {
+		"prefix": "fal",
+		"body": ".false.",
+		"description": ".false.",
 		"scope": "source.fortran"
 	},
-	"T": {
-		"prefix": "T",
-		"body": ".TRUE.",
-		"description": ".TRUE.",
+	"tr": {
+		"prefix": "tr",
+		"body": ".true.",
+		"description": ".true.",
 		"scope": "source.fortran"
 	}
 }

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -51,7 +51,7 @@
   },
   "close": {
     "prefix": "close",
-    "body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\nif ( $2 /= 0 ) stop \"Error closing file unit $1\"\n",
+    "body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\nif ($2 /= 0) stop \"Error closing file unit $1\"\n",
     "description": "Close File",
     "scope": "source.fortran"
   },
@@ -87,7 +87,7 @@
   },
   "dow": {
     "prefix": "dow",
-    "body": "do while ( ${1:condition} )\n\t$0\nend do",
+    "body": "do while (${1:condition})\n\t$0\nend do",
     "description": "do while",
     "scope": "source.fortran"
   },
@@ -105,8 +105,8 @@
   },
   "elif": {
     "prefix": "elif",
-    "body": "elseif ( ${1:condition} ) then\n\t",
-    "description": "elseif",
+    "body": "else if (${1:condition}) then\n\t",
+    "description": "else if",
     "scope": "source.fortran"
   },
   "eq": {
@@ -153,13 +153,13 @@
   },
   "if": {
     "prefix": "if",
-    "body": "if ( ${1:condition} ) ",
+    "body": "if (${1:condition}) ",
     "description": "if (single line)",
     "scope": "source.fortran"
   },
   "if1": {
     "prefix": "if",
-    "body": "if ( ${1:condition} ) then\n\t$0\nend if",
+    "body": "if (${1:condition}) then\n\t$0\nend if",
     "description": "if",
     "scope": "source.fortran"
   },
@@ -189,7 +189,7 @@
   },
   "open": {
     "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\nif ($3 /= 0) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
     "description": "Input File",
     "scope": "source.fortran"
   },
@@ -303,7 +303,7 @@
   },
   "open1": {
     "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\nif ($3 /= 0) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
     "description": "Open File",
     "scope": "source.fortran"
   },
@@ -315,7 +315,7 @@
   },
   "open2": {
     "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\nif ($3 /= 0) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
     "description": "Output File",
     "scope": "source.fortran"
   },
@@ -369,7 +369,7 @@
   },
   "op": {
     "prefix": "op",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\nif ($3 /= 0) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
     "description": "Quick Open",
     "scope": "source.fortran"
   },
@@ -405,13 +405,13 @@
   },
   "read": {
     "prefix": "read",
-    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\nif ($3 /= 0) stop \"Read error in file unit $1\"\n",
     "description": "Read (Non Advancing Mode)",
     "scope": "source.fortran"
   },
   "read1": {
     "prefix": "read",
-    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\nif ($3 /= 0) stop \"Read error in file unit $1\"\n",
     "description": "Read",
     "scope": "source.fortran"
   },
@@ -429,7 +429,7 @@
   },
   "open3": {
     "prefix": "open",
-    "body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\nif ( $3 /= 0 ) stop \"Error opening scratch file on unit $1\"\n",
+    "body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\nif ($3 /= 0) stop \"Error opening scratch file on unit $1\"\n",
     "description": "Scratch File",
     "scope": "source.fortran"
   },
@@ -489,19 +489,19 @@
   },
   "wh": {
     "prefix": "wh",
-    "body": "where ( $1 ${2:==} $3 ) ",
+    "body": "where ($1 ${2:==} $3) ",
     "description": "where (single line)",
     "scope": "source.fortran"
   },
   "whe": {
     "prefix": "whe",
-    "body": "where ( $1 ${2:==} $3 )\n\t$0\nend where",
+    "body": "where ($1 ${2:==} $3)\n\t$0\nend where",
     "description": "where",
     "scope": "source.fortran"
   },
   "write": {
     "prefix": "write",
-    "body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\nif ( $3 /= 0 ) stop \"Write error in file unit $1\"\n",
+    "body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\nif ($3 /= 0) stop \"Write error in file unit $1\"\n",
     "description": "Write",
     "scope": "source.fortran"
   },

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -459,7 +459,7 @@
 	},
 	"sub": {
 		"prefix": "sub",
-		"body": "subroutine ${1:name}\n\t${2:argument type}, intent(${3:inout}) :: ${1/\\w+\\((.*)\\)|.*/$1/}\n\t$0\nend subroutine ${1/(\\w+).*/$1/}",
+		"body": "subroutine ${1:name}(${2:input})\n\t${3:argument type}, intent(${4:inout}) :: ${2/\\w+\\((.*)\\)|.*/$2/}\n\t$0\nend subroutine ${1/(\\w+).*/$1/}",
 		"description": "subroutine",
 		"scope": "source.fortran"
 	},

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -1,520 +1,520 @@
 {
-  "all": {
-    "prefix": "all",
-    "body": "all(${1:mask}${2:, dim=${3:1}})",
-    "description": "all",
-    "scope": "source.fortran"
-  },
-  "alloc": {
-    "prefix": "alloc",
-    "body": [
-      "allocate(${1:array}, stat=${2:err})",
-      "if ($2 /= 0) print *, \"$1: Allocation request denied\"",
-      "",
-      "if (allocated($1)) deallocate($1, stat=$2)",
-      "if ($2 /= 0) print *, \"$1: Deallocation request denied\""
-    ],
-    "description": "Allocate and Deallocate array",
-    "scope": "source.fortran"
-  },
-  "al": {
-    "body": [
-      "allocate(${1:array}, stat=${2:err})",
-      "if ($2 /= 0) print *, \"$1: Allocation request denied\""
-    ],
-    "prefix": "al",
-    "description": "Allocate Array"
-  },
-  "and": {
-    "prefix": "and",
-    "body": ".and.",
-    "description": "And",
-    "scope": "source.fortran"
-  },
-  "any": {
-    "prefix": "any",
-    "body": "any(${1:mask}${2:, dim=${3:1}})",
-    "description": "any",
-    "scope": "source.fortran"
-  },
-  "case": {
-    "prefix": "case",
-    "body": "case ${1:default}\r\n\t$0",
-    "description": "case",
-    "scope": "source.fortran"
-  },
-  "char": {
-    "prefix": "char",
-    "body": "character(len=$1${2:, kind=$3})${4:, ${5:attributes}} :: ${6:name}",
-    "description": "Character",
-    "scope": "source.fortran"
-  },
-  "close": {
-    "prefix": "close",
-    "body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\r\nif ( $2 /= 0 ) stop \"Error closing file unit $1\"\r\n",
-    "description": "Close File",
-    "scope": "source.fortran"
-  },
-  "count": {
-    "prefix": "count",
-    "body": "count(${1:mask}${2:, dim=${3:1}})",
-    "description": "count",
-    "scope": "source.fortran"
-  },
-  "typ": {
-    "prefix": "typ",
-    "body": "type(${1:type name})${2:, ${3:attributes}} :: ${4:name}",
-    "description": "Custom Type",
-    "scope": "source.fortran"
-  },
-  "cy": {
-    "prefix": "cy",
-    "body": "cycle",
-    "description": "cycle",
-    "scope": "source.fortran"
-  },
-  "data": {
-    "prefix": "data",
-    "body": "data ${1:variable} / ${2:data} /",
-    "description": "data",
-    "scope": "source.fortran"
-  },
-  "deal": {
-    "prefix": "deal",
-    "body": "if (allocated($1)) deallocate(${1:array}, stat=${2:err})\r\nif ($2 /= 0) print *, \"$1: Deallocation request denied$0\"",
-    "description": "Deallocate Array",
-    "scope": "source.fortran"
-  },
-  "dow": {
-    "prefix": "dow",
-    "body": "do while ( ${1:condition} )\r\n\t$0\r\nend do",
-    "description": "do while",
-    "scope": "source.fortran"
-  },
-  "do": {
-    "prefix": "do",
-    "body": "do${1: ${2:i} = ${3:1}, ${4:100}, ${5:1}}\r\n\t$0\r\nend do",
-    "description": "do",
-    "scope": "source.fortran"
-  },
-  "dot": {
-    "prefix": "dot",
-    "body": "dot_product($1,$2)",
-    "description": "Dot Product of Vectors",
-    "scope": "source.fortran"
-  },
-  "elif": {
-    "prefix": "elif",
-    "body": "elseif ( ${1:condition} ) then\r\n\t",
-    "description": "elseif",
-    "scope": "source.fortran"
-  },
-  "eq": {
-    "prefix": "eq",
-    "body": ".eq.",
-    "description": "Equal",
-    "scope": "source.fortran"
-  },
-  "eqv": {
-    "prefix": "eqv",
-    "body": ".eqv.",
-    "description": "Equality",
-    "scope": "source.fortran"
-  },
-  "for": {
-    "prefix": "for",
-    "body": "forall (${1:i=1:100}${2:, mask})\r\n\t$0\r\nend forall",
-    "description": "forall",
-    "scope": "source.fortran.modern"
-  },
-  "fun": {
-    "prefix": "fun",
-    "body": [
-      "function ${1:name}(${2:input}) result(${3:output})",
-      "\t${4:argument type}, intent(${5:inout}) :: $2",
-      "\t${6:function type} :: $3",
-      "\t$0",
-      "end function $1"
-    ],
-    "description": "function",
-    "scope": "source.fortran"
-  },
-  "ge": {
-    "prefix": "ge",
-    "body": ".ge.",
-    "description": "Greater or Equal",
-    "scope": "source.fortran"
-  },
-  "gt": {
-    "prefix": "gt",
-    "body": ".gt.",
-    "description": "Greater Than",
-    "scope": "source.fortran"
-  },
-  "if": {
-    "prefix": "if",
-    "body": "if ( ${1:condition} ) ",
-    "description": "if (single line)",
-    "scope": "source.fortran"
-  },
-  "if1": {
-    "prefix": "if",
-    "body": "if ( ${1:condition} ) then\r\n\t$0\r\nend if",
-    "description": "if",
-    "scope": "source.fortran"
-  },
-  "imp": {
-    "prefix": "imp",
-    "body": "implicit none\r\n",
-    "description": "implicit none",
-    "scope": "source.fortran"
-  },
-  "ido": {
-    "prefix": "ido",
-    "body": "(${1:i}, $1 = ${2:1}, ${3:100}, ${4:1})$0",
-    "description": "Implied do",
-    "scope": "source.fortran"
-  },
-  "maxloc": {
-    "prefix": "maxloc",
-    "body": "maxloc(${1:source}${2:, mask=${3:($1>0)}})",
-    "description": "Index of Maximum",
-    "scope": "source.fortran"
-  },
-  "minloc": {
-    "prefix": "minloc",
-    "body": "minloc(${1:source}${2:, mask=${3:$1>0}})",
-    "description": "Index of Minimum",
-    "scope": "source.fortran"
-  },
-  "open": {
-    "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\r\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\r\n",
-    "description": "Input File",
-    "scope": "source.fortran"
-  },
-  "inq": {
-    "prefix": "inq",
-    "body": "inquire(file=${1:filename}, opened=${2:ioopen}, exists=${3:ioexist}, number=${4:iounit})",
-    "description": "Inquire (by Filename)",
-    "scope": "source.fortran"
-  },
-  "inq1": {
-    "prefix": "inq",
-    "body": "inquire(unit=${1:iounit}, opened=${2:ioopen}, name=${3:filename}, action=${4:ioaction})",
-    "description": "Inquire (by Unit)",
-    "scope": "source.fortran"
-  },
-  "int": {
-    "prefix": "int",
-    "body": "integer${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-    "description": "Integer",
-    "scope": "source.fortran"
-  },
-  "interf": {
-    "prefix": "interf",
-    "body": "interface ${1:name}\r\n\t$0\r\nend interface ! $1",
-    "description": "interface",
-    "scope": "source.fortran"
-  },
-  "le": {
-    "prefix": "le",
-    "body": ".le.",
-    "description": "Less or Equal",
-    "scope": "source.fortran"
-  },
-  "lt": {
-    "prefix": "lt",
-    "body": ".lt.",
-    "description": "Less Than",
-    "scope": "source.fortran"
-  },
-  "log": {
-    "prefix": "log",
-    "body": "logical${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-    "description": "Logical",
-    "scope": "source.fortran"
-  },
-  "lbound": {
-    "prefix": "lbound",
-    "body": "lbound(${1:source}${2:, dim=${3:1}})",
-    "description": "Lower Bound",
-    "scope": "source.fortran"
-  },
-  "mat": {
-    "prefix": "mat",
-    "body": "matmul($1,$2)",
-    "description": "Matrix Multiplication",
-    "scope": "source.fortran"
-  },
-  "max": {
-    "prefix": "max",
-    "body": "max($1, $2${, $3:...})$0",
-    "description": "max",
-    "scope": "source.fortran"
-  },
-  "maxval": {
-    "prefix": "maxval",
-    "body": "maxval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-    "description": "Maximum Value",
-    "scope": "source.fortran"
-  },
-  "merge": {
-    "prefix": "merge",
-    "body": "merge(${1:source}, ${2:alternative}, mask=(${2:$1>0}))",
-    "description": "merge",
-    "scope": "source.fortran"
-  },
-  "min": {
-    "prefix": "min",
-    "body": "min($1, $2${, $3:...})$0",
-    "description": "min",
-    "scope": "source.fortran"
-  },
-  "minval": {
-    "prefix": "minval",
-    "body": "minval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-    "description": "Minimum Value",
-    "scope": "source.fortran"
-  },
-  "mp": {
-    "prefix": "mp",
-    "body": "module procedure ${0:name}",
-    "description": "module procedure",
-    "scope": "source.fortran"
-  },
-  "mod": {
-    "prefix": "mod",
-    "body": "module ${1:name}\r\n\r\n\timplicit none\r\n\t$0\r\n\r\nend module $1\r\n",
-    "description": "module",
-    "scope": "source.fortran"
-  },
-  "neqv": {
-    "prefix": "neqv",
-    "body": ".neqv.",
-    "description": "Non-Equality",
-    "scope": "source.fortran"
-  },
-  "not": {
-    "prefix": "not",
-    "body": ".not.",
-    "description": "Not",
-    "scope": "source.fortran"
-  },
-  "open1": {
-    "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\r\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\r\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
-    "description": "Open File",
-    "scope": "source.fortran"
-  },
-  "or": {
-    "prefix": "or",
-    "body": ".or.",
-    "description": "Or",
-    "scope": "source.fortran"
-  },
-  "open2": {
-    "prefix": "open",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\r\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\r\n",
-    "description": "Output File",
-    "scope": "source.fortran"
-  },
-  "pack": {
-    "prefix": "pack",
-    "body": "pack(${1:array}, mask=(${2:$1>0})${3:, vector=${4:destination vector}})",
-    "description": "pack",
-    "scope": "source.fortran"
-  },
-  "pr": {
-    "prefix": "pr",
-    "body": "print*, ",
-    "description": "Quick Print",
-    "scope": "source.fortran"
-  },
-  "prod": {
-    "prefix": "prod",
-    "body": "product(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-    "description": "Product of Elements",
-    "scope": "source.fortran"
-  },
-  "prog": {
-    "prefix": "prog",
-    "body": "program ${1:name}\r\n\r\n\timplicit none\r\n\t$0\r\n\r\nend program $1\r\n",
-    "description": "program",
-    "scope": "source.fortran"
-  },
-  "c": {
-    "prefix": "c",
-    "body": "character(len=*) :: ",
-    "description": "Quick Character",
-    "scope": "source.fortran"
-  },
-  "t": {
-    "prefix": "t",
-    "body": "type(${1:type name}) :: ",
-    "description": "Quick Custom Type",
-    "scope": "source.fortran"
-  },
-  "i": {
-    "prefix": "i",
-    "body": "integer :: ",
-    "description": "Quick Integer",
-    "scope": "source.fortran"
-  },
-  "l": {
-    "prefix": "l",
-    "body": "logical :: ",
-    "description": "Quick Logical",
-    "scope": "source.fortran"
-  },
-  "op": {
-    "prefix": "op",
-    "body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\r\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
-    "description": "Quick Open",
-    "scope": "source.fortran"
-  },
-  "re": {
-    "prefix": "re",
-    "body": "read*, ",
-    "description": "Quick Read",
-    "scope": "source.fortran"
-  },
-  "r": {
-    "prefix": "r",
-    "body": "real :: ",
-    "description": "Quick Real",
-    "scope": "source.fortran"
-  },
-  "wr": {
-    "prefix": "wr",
-    "body": "write(unit=${1:iounit}, fmt=*) ${0:variables}\r\n",
-    "description": "Quick Write",
-    "scope": "source.fortran"
-  },
-  "rn": {
-    "prefix": "rn",
-    "body": "call random_number($0)",
-    "description": "Random Number",
-    "scope": "source.fortran"
-  },
-  "rs": {
-    "prefix": "rs",
-    "body": "call random_seed(${1:size=${2:<int>}}${3:put=(/$4/)})",
-    "description": "Random Seed",
-    "scope": "source.fortran"
-  },
-  "read": {
-    "prefix": "read",
-    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\r\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\r\n",
-    "description": "Read (Non Advancing Mode)",
-    "scope": "source.fortran"
-  },
-  "read1": {
-    "prefix": "read",
-    "body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\r\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\r\n",
-    "description": "Read",
-    "scope": "source.fortran"
-  },
-  "rea": {
-    "prefix": "rea",
-    "body": "real${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
-    "description": "Real",
-    "scope": "source.fortran"
-  },
-  "resh": {
-    "prefix": "resh",
-    "body": "reshape(${1:source}${2:, shape=(/$3/)}${4:, pad=(/$5/)}${6:, order=(/${7:2,1}/)})",
-    "description": "reshape",
-    "scope": "source.fortran"
-  },
-  "open3": {
-    "prefix": "open",
-    "body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\r\nif ( $3 /= 0 ) stop \"Error opening scratch file on unit $1\"\r\n",
-    "description": "Scratch File",
-    "scope": "source.fortran"
-  },
-  "sel": {
-    "prefix": "sel",
-    "body": "select case ($1:variable)\r\n\tcase ($2:values)\r\n\t\t$0\r\nend select",
-    "description": "select case",
-    "scope": "source.fortran"
-  },
-  "size": {
-    "prefix": "size",
-    "body": "size(${1:source}${2:, dim=${3:1}})",
-    "description": "Size",
-    "scope": "source.fortran"
-  },
-  "spread": {
-    "prefix": "spread",
-    "body": "spread(${1:source}, dim=${2:1}, ncopies=$3)",
-    "description": "spread",
-    "scope": "source.fortran"
-  },
-  "stop": {
-    "prefix": "stop",
-    "body": "stop \"${1:message}\"",
-    "description": "stop",
-    "scope": "source.fortran"
-  },
-  "sub": {
-    "prefix": "sub",
-    "body": "subroutine ${1:name}\r\n\t${2:argument type}, intent(${3:inout}) :: ${1/\\w+\\((.*)\\)|.*/$1/}\r\n\t$0\r\nend subroutine ${1/(\\w+).*/$1/}",
-    "description": "subroutine",
-    "scope": "source.fortran"
-  },
-  "sum": {
-    "prefix": "sum",
-    "body": "sum(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
-    "description": "Sum of Elements",
-    "scope": "source.fortran"
-  },
-  "type": {
-    "prefix": "type",
-    "body": "type ${1:type name}\r\n\t$0\r\nend type $1",
-    "description": "Type Definition",
-    "scope": "source.fortran"
-  },
-  "unpack": {
-    "prefix": "unpack",
-    "body": "unpack(${1:vector}, mask=(${2:$1>0}), field=${3:destination array})",
-    "description": "unpack",
-    "scope": "source.fortran"
-  },
-  "ubound": {
-    "prefix": "ubound",
-    "body": "ubound(${1:source}${2:, dim=${3:1}})",
-    "description": "Upper Bound",
-    "scope": "source.fortran"
-  },
-  "wh": {
-    "prefix": "wh",
-    "body": "where ( $1 ${2:==} $3 ) ",
-    "description": "where (single line)",
-    "scope": "source.fortran"
-  },
-  "whe": {
-    "prefix": "whe",
-    "body": "where ( $1 ${2:==} $3 )\r\n\t$0\r\nend where",
-    "description": "where",
-    "scope": "source.fortran"
-  },
-  "write": {
-    "prefix": "write",
-    "body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\r\nif ( $3 /= 0 ) stop \"Write error in file unit $1\"\r\n",
-    "description": "Write",
-    "scope": "source.fortran"
-  },
-  "F": {
-    "prefix": "F",
-    "body": ".FALSE.",
-    "description": ".FALSE.",
-    "scope": "source.fortran"
-  },
-  "T": {
-    "prefix": "T",
-    "body": ".TRUE.",
-    "description": ".TRUE.",
-    "scope": "source.fortran"
-  }
+	"all": {
+		"prefix": "all",
+		"body": "all(${1:mask}${2:, dim=${3:1}})",
+		"description": "all",
+		"scope": "source.fortran"
+	},
+	"alloc": {
+		"prefix": "alloc",
+		"body": [
+			"allocate(${1:array}, stat=${2:err})",
+			"if ($2 /= 0) print *, \"$1: Allocation request denied\"",
+			"",
+			"if (allocated($1)) deallocate($1, stat=$2)",
+			"if ($2 /= 0) print *, \"$1: Deallocation request denied\""
+		],
+		"description": "Allocate and Deallocate array",
+		"scope": "source.fortran"
+	},
+	"al": {
+		"body": [
+			"allocate(${1:array}, stat=${2:err})",
+			"if ($2 /= 0) print *, \"$1: Allocation request denied\""
+		],
+		"prefix": "al",
+		"description": "Allocate Array"
+	},
+	"and": {
+		"prefix": "and",
+		"body": ".and.",
+		"description": "And",
+		"scope": "source.fortran"
+	},
+	"any": {
+		"prefix": "any",
+		"body": "any(${1:mask}${2:, dim=${3:1}})",
+		"description": "any",
+		"scope": "source.fortran"
+	},
+	"case": {
+		"prefix": "case",
+		"body": "case ${1:default}\n\t$0",
+		"description": "case",
+		"scope": "source.fortran"
+	},
+	"char": {
+		"prefix": "char",
+		"body": "character(len=$1${2:, kind=$3})${4:, ${5:attributes}} :: ${6:name}",
+		"description": "Character",
+		"scope": "source.fortran"
+	},
+	"close": {
+		"prefix": "close",
+		"body": "close(unit=${1:iounit}, iostat=${2:ios}${3:, status=\"delete\"})\nif ( $2 /= 0 ) stop \"Error closing file unit $1\"\n",
+		"description": "Close File",
+		"scope": "source.fortran"
+	},
+	"count": {
+		"prefix": "count",
+		"body": "count(${1:mask}${2:, dim=${3:1}})",
+		"description": "count",
+		"scope": "source.fortran"
+	},
+	"typ": {
+		"prefix": "typ",
+		"body": "type(${1:type name})${2:, ${3:attributes}} :: ${4:name}",
+		"description": "Custom Type",
+		"scope": "source.fortran"
+	},
+	"cy": {
+		"prefix": "cy",
+		"body": "cycle",
+		"description": "cycle",
+		"scope": "source.fortran"
+	},
+	"data": {
+		"prefix": "data",
+		"body": "data ${1:variable} / ${2:data} /",
+		"description": "data",
+		"scope": "source.fortran"
+	},
+	"deal": {
+		"prefix": "deal",
+		"body": "if (allocated($1)) deallocate(${1:array}, stat=${2:err})\nif ($2 /= 0) print *, \"$1: Deallocation request denied$0\"",
+		"description": "Deallocate Array",
+		"scope": "source.fortran"
+	},
+	"dow": {
+		"prefix": "dow",
+		"body": "do while ( ${1:condition} )\n\t$0\nend do",
+		"description": "do while",
+		"scope": "source.fortran"
+	},
+	"do": {
+		"prefix": "do",
+		"body": "do${1: ${2:i} = ${3:1}, ${4:100}, ${5:1}}\n\t$0\nend do",
+		"description": "do",
+		"scope": "source.fortran"
+	},
+	"dot": {
+		"prefix": "dot",
+		"body": "dot_product($1,$2)",
+		"description": "Dot Product of Vectors",
+		"scope": "source.fortran"
+	},
+	"elif": {
+		"prefix": "elif",
+		"body": "elseif ( ${1:condition} ) then\n\t",
+		"description": "elseif",
+		"scope": "source.fortran"
+	},
+	"eq": {
+		"prefix": "eq",
+		"body": ".eq.",
+		"description": "Equal",
+		"scope": "source.fortran"
+	},
+	"eqv": {
+		"prefix": "eqv",
+		"body": ".eqv.",
+		"description": "Equality",
+		"scope": "source.fortran"
+	},
+	"for": {
+		"prefix": "for",
+		"body": "forall (${1:i=1:100}${2:, mask})\n\t$0\nend forall",
+		"description": "forall",
+		"scope": "source.fortran.modern"
+	},
+	"fun": {
+		"prefix": "fun",
+		"body": [
+			"function ${1:name}(${2:input}) result(${3:output})",
+			"\t${4:argument type}, intent(${5:inout}) :: $2",
+			"\t${6:function type} :: $3",
+			"\t$0",
+			"end function $1"
+		],
+		"description": "function",
+		"scope": "source.fortran"
+	},
+	"ge": {
+		"prefix": "ge",
+		"body": ".ge.",
+		"description": "Greater or Equal",
+		"scope": "source.fortran"
+	},
+	"gt": {
+		"prefix": "gt",
+		"body": ".gt.",
+		"description": "Greater Than",
+		"scope": "source.fortran"
+	},
+	"if": {
+		"prefix": "if",
+		"body": "if ( ${1:condition} ) ",
+		"description": "if (single line)",
+		"scope": "source.fortran"
+	},
+	"if1": {
+		"prefix": "if",
+		"body": "if ( ${1:condition} ) then\n\t$0\nend if",
+		"description": "if",
+		"scope": "source.fortran"
+	},
+	"imp": {
+		"prefix": "imp",
+		"body": "implicit none\n",
+		"description": "implicit none",
+		"scope": "source.fortran"
+	},
+	"ido": {
+		"prefix": "ido",
+		"body": "(${1:i}, $1 = ${2:1}, ${3:100}, ${4:1})$0",
+		"description": "Implied do",
+		"scope": "source.fortran"
+	},
+	"maxloc": {
+		"prefix": "maxloc",
+		"body": "maxloc(${1:source}${2:, mask=${3:($1>0)}})",
+		"description": "Index of Maximum",
+		"scope": "source.fortran"
+	},
+	"minloc": {
+		"prefix": "minloc",
+		"body": "minloc(${1:source}${2:, mask=${3:$1>0}})",
+		"description": "Index of Minimum",
+		"scope": "source.fortran"
+	},
+	"open": {
+		"prefix": "open",
+		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:old}\", action=\"${5:read}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+		"description": "Input File",
+		"scope": "source.fortran"
+	},
+	"inq": {
+		"prefix": "inq",
+		"body": "inquire(file=${1:filename}, opened=${2:ioopen}, exists=${3:ioexist}, number=${4:iounit})",
+		"description": "Inquire (by Filename)",
+		"scope": "source.fortran"
+	},
+	"inq1": {
+		"prefix": "inq",
+		"body": "inquire(unit=${1:iounit}, opened=${2:ioopen}, name=${3:filename}, action=${4:ioaction})",
+		"description": "Inquire (by Unit)",
+		"scope": "source.fortran"
+	},
+	"int": {
+		"prefix": "int",
+		"body": "integer${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+		"description": "Integer",
+		"scope": "source.fortran"
+	},
+	"interf": {
+		"prefix": "interf",
+		"body": "interface ${1:name}\n\t$0\nend interface ! $1",
+		"description": "interface",
+		"scope": "source.fortran"
+	},
+	"le": {
+		"prefix": "le",
+		"body": ".le.",
+		"description": "Less or Equal",
+		"scope": "source.fortran"
+	},
+	"lt": {
+		"prefix": "lt",
+		"body": ".lt.",
+		"description": "Less Than",
+		"scope": "source.fortran"
+	},
+	"log": {
+		"prefix": "log",
+		"body": "logical${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+		"description": "Logical",
+		"scope": "source.fortran"
+	},
+	"lbound": {
+		"prefix": "lbound",
+		"body": "lbound(${1:source}${2:, dim=${3:1}})",
+		"description": "Lower Bound",
+		"scope": "source.fortran"
+	},
+	"mat": {
+		"prefix": "mat",
+		"body": "matmul($1,$2)",
+		"description": "Matrix Multiplication",
+		"scope": "source.fortran"
+	},
+	"max": {
+		"prefix": "max",
+		"body": "max($1, $2${, $3:...})$0",
+		"description": "max",
+		"scope": "source.fortran"
+	},
+	"maxval": {
+		"prefix": "maxval",
+		"body": "maxval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+		"description": "Maximum Value",
+		"scope": "source.fortran"
+	},
+	"merge": {
+		"prefix": "merge",
+		"body": "merge(${1:source}, ${2:alternative}, mask=(${2:$1>0}))",
+		"description": "merge",
+		"scope": "source.fortran"
+	},
+	"min": {
+		"prefix": "min",
+		"body": "min($1, $2${, $3:...})$0",
+		"description": "min",
+		"scope": "source.fortran"
+	},
+	"minval": {
+		"prefix": "minval",
+		"body": "minval(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+		"description": "Minimum Value",
+		"scope": "source.fortran"
+	},
+	"mp": {
+		"prefix": "mp",
+		"body": "module procedure ${0:name}",
+		"description": "module procedure",
+		"scope": "source.fortran"
+	},
+	"mod": {
+		"prefix": "mod",
+		"body": "module ${1:name}\n\n\timplicit none\n\t$0\n\nend module $1\n",
+		"description": "module",
+		"scope": "source.fortran"
+	},
+	"neqv": {
+		"prefix": "neqv",
+		"body": ".neqv.",
+		"description": "Non-Equality",
+		"scope": "source.fortran"
+	},
+	"not": {
+		"prefix": "not",
+		"body": ".not.",
+		"description": "Not",
+		"scope": "source.fortran"
+	},
+	"open1": {
+		"prefix": "open",
+		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, &\n     status=\"${4:old/new/replace/scratch/unknown}\", action=\"${5:read/write/readwrite}\", access=\"${7:sequential/direct}\"${7/(direct)$|.*/(?1:, recl=)/}$0)\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+		"description": "Open File",
+		"scope": "source.fortran"
+	},
+	"or": {
+		"prefix": "or",
+		"body": ".or.",
+		"description": "Or",
+		"scope": "source.fortran"
+	},
+	"open2": {
+		"prefix": "open",
+		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios}, status=\"${4:new}\", action=\"${5:write}\")\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"\n",
+		"description": "Output File",
+		"scope": "source.fortran"
+	},
+	"pack": {
+		"prefix": "pack",
+		"body": "pack(${1:array}, mask=(${2:$1>0})${3:, vector=${4:destination vector}})",
+		"description": "pack",
+		"scope": "source.fortran"
+	},
+	"pr": {
+		"prefix": "pr",
+		"body": "print*, ",
+		"description": "Quick Print",
+		"scope": "source.fortran"
+	},
+	"prod": {
+		"prefix": "prod",
+		"body": "product(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+		"description": "Product of Elements",
+		"scope": "source.fortran"
+	},
+	"prog": {
+		"prefix": "prog",
+		"body": "program ${1:name}\n\n\timplicit none\n\t$0\n\nend program $1\n",
+		"description": "program",
+		"scope": "source.fortran"
+	},
+	"c": {
+		"prefix": "c",
+		"body": "character(len=*) :: ",
+		"description": "Quick Character",
+		"scope": "source.fortran"
+	},
+	"t": {
+		"prefix": "t",
+		"body": "type(${1:type name}) :: ",
+		"description": "Quick Custom Type",
+		"scope": "source.fortran"
+	},
+	"i": {
+		"prefix": "i",
+		"body": "integer :: ",
+		"description": "Quick Integer",
+		"scope": "source.fortran"
+	},
+	"l": {
+		"prefix": "l",
+		"body": "logical :: ",
+		"description": "Quick Logical",
+		"scope": "source.fortran"
+	},
+	"op": {
+		"prefix": "op",
+		"body": "open(unit=${1:iounit}, file=${2:name}, iostat=${3:ios})\nif ( $3 /= 0 ) stop \"Error opening file ${2/[\\\"\\'](.*)[\\\"\\']/$1/}\"",
+		"description": "Quick Open",
+		"scope": "source.fortran"
+	},
+	"re": {
+		"prefix": "re",
+		"body": "read*, ",
+		"description": "Quick Read",
+		"scope": "source.fortran"
+	},
+	"r": {
+		"prefix": "r",
+		"body": "real :: ",
+		"description": "Quick Real",
+		"scope": "source.fortran"
+	},
+	"wr": {
+		"prefix": "wr",
+		"body": "write(unit=${1:iounit}, fmt=*) ${0:variables}\n",
+		"description": "Quick Write",
+		"scope": "source.fortran"
+	},
+	"rn": {
+		"prefix": "rn",
+		"body": "call random_number($0)",
+		"description": "Random Number",
+		"scope": "source.fortran"
+	},
+	"rs": {
+		"prefix": "rs",
+		"body": "call random_seed(${1:size=${2:<int>}}${3:put=(/$4/)})",
+		"description": "Random Seed",
+		"scope": "source.fortran"
+	},
+	"read": {
+		"prefix": "read",
+		"body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}, advance='NO', size=${4:number of characters}) ${5:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+		"description": "Read (Non Advancing Mode)",
+		"scope": "source.fortran"
+	},
+	"read1": {
+		"prefix": "read",
+		"body": "read(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:istat}) ${4:variables}\nif ( $3 /= 0 ) stop \"Read error in file unit $1\"\n",
+		"description": "Read",
+		"scope": "source.fortran"
+	},
+	"rea": {
+		"prefix": "rea",
+		"body": "real${1:(${2:kind})}${3:, ${4:attributes}} :: ${5:name}",
+		"description": "Real",
+		"scope": "source.fortran"
+	},
+	"resh": {
+		"prefix": "resh",
+		"body": "reshape(${1:source}${2:, shape=(/$3/)}${4:, pad=(/$5/)}${6:, order=(/${7:2,1}/)})",
+		"description": "reshape",
+		"scope": "source.fortran"
+	},
+	"open3": {
+		"prefix": "open",
+		"body": "open(unit=${1:iounit}, iostat=${3:ios}, status=\"${4:scratch}\", action=\"${5:readwrite}\")\nif ( $3 /= 0 ) stop \"Error opening scratch file on unit $1\"\n",
+		"description": "Scratch File",
+		"scope": "source.fortran"
+	},
+	"sel": {
+		"prefix": "sel",
+		"body": "select case ($1:variable)\n\tcase ($2:values)\n\t\t$0\nend select",
+		"description": "select case",
+		"scope": "source.fortran"
+	},
+	"size": {
+		"prefix": "size",
+		"body": "size(${1:source}${2:, dim=${3:1}})",
+		"description": "Size",
+		"scope": "source.fortran"
+	},
+	"spread": {
+		"prefix": "spread",
+		"body": "spread(${1:source}, dim=${2:1}, ncopies=$3)",
+		"description": "spread",
+		"scope": "source.fortran"
+	},
+	"stop": {
+		"prefix": "stop",
+		"body": "stop \"${1:message}\"",
+		"description": "stop",
+		"scope": "source.fortran"
+	},
+	"sub": {
+		"prefix": "sub",
+		"body": "subroutine ${1:name}\n\t${2:argument type}, intent(${3:inout}) :: ${1/\\w+\\((.*)\\)|.*/$1/}\n\t$0\nend subroutine ${1/(\\w+).*/$1/}",
+		"description": "subroutine",
+		"scope": "source.fortran"
+	},
+	"sum": {
+		"prefix": "sum",
+		"body": "sum(${1:source}${2:, dim=${3:1}}${4:, mask=${5:($1>0)}})",
+		"description": "Sum of Elements",
+		"scope": "source.fortran"
+	},
+	"type": {
+		"prefix": "type",
+		"body": "type ${1:type name}\n\t$0\nend type $1",
+		"description": "Type Definition",
+		"scope": "source.fortran"
+	},
+	"unpack": {
+		"prefix": "unpack",
+		"body": "unpack(${1:vector}, mask=(${2:$1>0}), field=${3:destination array})",
+		"description": "unpack",
+		"scope": "source.fortran"
+	},
+	"ubound": {
+		"prefix": "ubound",
+		"body": "ubound(${1:source}${2:, dim=${3:1}})",
+		"description": "Upper Bound",
+		"scope": "source.fortran"
+	},
+	"wh": {
+		"prefix": "wh",
+		"body": "where ( $1 ${2:==} $3 ) ",
+		"description": "where (single line)",
+		"scope": "source.fortran"
+	},
+	"whe": {
+		"prefix": "whe",
+		"body": "where ( $1 ${2:==} $3 )\n\t$0\nend where",
+		"description": "where",
+		"scope": "source.fortran"
+	},
+	"write": {
+		"prefix": "write",
+		"body": "write(unit=${1:iounit}, fmt=\"(${2:format string})\", iostat=${3:ios}${4:, advance='NO'}) ${5:variables}\nif ( $3 /= 0 ) stop \"Write error in file unit $1\"\n",
+		"description": "Write",
+		"scope": "source.fortran"
+	},
+	"F": {
+		"prefix": "F",
+		"body": ".FALSE.",
+		"description": ".FALSE.",
+		"scope": "source.fortran"
+	},
+	"T": {
+		"prefix": "T",
+		"body": ".TRUE.",
+		"description": ".TRUE.",
+		"scope": "source.fortran"
+	}
 }


### PR DESCRIPTION
I mainly removed the `\r` characters. Then I also fixed `sub` and `interf`, made `.true.` and `.false` consistent (lowercase) with the rest of the snippets and removed the unnecessary whitespaces for the if statement conditions.