### PR TITLE
Html snippets for react && javascriptreact && htmldjango

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
           "html",
           "jade",
           "pug",
-          "eruby"
+          "eruby",
+          "javascriptreact",
         ],
         "path": "./snippets/html.json"
       },

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
           "jade",
           "pug",
           "eruby",
-          "javascriptreact"
+          "javascriptreact",
+          "htmldjango"
         ],
         "path": "./snippets/html.json"
       },

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
           "jade",
           "pug",
           "eruby",
-          "javascriptreact",
+          "javascriptreact"
         ],
         "path": "./snippets/html.json"
       },


### PR DESCRIPTION
maybe it is necessary to extend hmtl snippet for jsx filetype.
 #31
https://github.com/rafamadriz/friendly-snippets/issues/31#issuecomment-1097517567

```lua
require('luasnip').filetype_extend("javascriptreact", { "html" })
```