### PR TITLE
add eupl license

### DIFF
--- a/snippets/global.json
+++ b/snippets/global.json
@@ -386,7 +386,7 @@
       "You may not use this work except in compliance with the Licence.",
       "You may obtain a copy of the Licence at:",
       "",
-      "<https://joinup.ec.europa.eu/software/page/eupl5>",
+      "<https://joinup.ec.europa.eu/software/page/eupl>",
       "",
       "Unless required by applicable law or agreed to in writing, software distributed under the Licence is distributed on an ''AS IS'' basis,",
       "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",

--- a/snippets/global.json
+++ b/snippets/global.json
@@ -374,5 +374,23 @@
       "",
       "THE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE."
     ]
+  },
+  "EUPL": {
+    "prefix": "EUPL",
+    "description": "EUPL License",
+    "body": [
+      "The EUPL License (EUPL)",
+      "",
+      "Copyright (c) ${CURRENT_YEAR} ${0:Author}",
+      "Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent versions of the EUPL (the ''Licence'');",
+      "You may not use this work except in compliance with the Licence.",
+      "You may obtain a copy of the Licence at:",
+      "",
+      "<https://joinup.ec.europa.eu/software/page/eupl5>",
+      "",
+      "Unless required by applicable law or agreed to in writing, software distributed under the Licence is distributed on an ''AS IS'' basis,",
+      "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+      "See the Licence for the specific language governing permissions and limitations under the Licence."
+    ]
   }
 }


### PR DESCRIPTION
Added EUPL license to global snippets. The long lines can also be separated, but I wanted to keep it as original as I could.