### PR TITLE
fix(lua): class snip

### DIFF
--- a/snippets/lua.json
+++ b/snippets/lua.json
@@ -39,7 +39,7 @@
         "body": [
             "${1:className} = {}\n",
             "$1.${2:new} = function($3)",
-            "\tlocal ${4:varName} = ${5:{}}\n",
+            "\tlocal ${4:varName} = ${5:value}\n",
             "\t${6: --code}\n",
             "\treturn $4",
             "end"


### PR DESCRIPTION
` "\tlocal ${4:varName} = ${5:{}}\n",`

In the case I use the class snip it will become:
` local temp = value}`

The correct being should be:
` local temp = value`

It seems that the 5th is match `${ 5:{ }` ,which makes a extra "}".

And change `${5:{}}` to `${5:value}` can avoid this problem.