### PR TITLE
fix: Ruby if-else snippets 

### DIFF
--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -92,7 +92,7 @@
 		]
 	},
 	"if elsif": {
-		"prefix": "if elsif",
+		"prefix": "ifei",
 		"body": [
 			"if ${1:test}",
 			"\t$0",
@@ -102,7 +102,7 @@
 		]
 	},
 	"if elsif else": {
-		"prefix": "if elsif else",
+		"prefix": "ifee",
 		"body": [
 			"if ${1:test}",
 			"\t$0",

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -21,20 +21,8 @@
 			"end"
 		]
 	},
-	"Exception block with else": {
-		"prefix": "begin else",
-		"body": [
-			"begin",
-			"\t$1",
-			"rescue => exception",
-			"\t",
-			"else",
-			"\t",
-			"end"
-		]
-	},
 	"Exception block with else and ensure": {
-		"prefix": "begin else ensure",
+		"prefix": "begin",
 		"body": [
 			"begin",
 			"\t$1",

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -82,7 +82,7 @@
 		]
 	},
 	"if else": {
-		"prefix": "if else",
+		"prefix": "ife",
 		"body": [
 			"if ${1:test}",
 			"\t$0",


### PR DESCRIPTION
This is an attempt to remedy the issues caused in #209 . 

### Summary 
- Renamed the `prefix` for a few snippets to match those of similar structure in the `honza/vim-snippets` repo
- Removed repetitive snippets in the exceptions (which also matched on the word `else`).

### To Test the updates

- Update your friendly snippets to point at my forks branch

```lua
use { "OkelleyDevelopment/friendly-snippets", branch = "fix-ruby-ifelse" }
-- use { "rafamadriz/friendly-snippets" }
```

- Run `:PackerSync` 
- Test again on a ruby file

Once you're done testing, you can then uncomment the previous repo and re-sync. :sunglasses: 
