### PR TITLE
norg link targets are now set in curly braces instead of normal ones

### DIFF
--- a/snippets/norg.json
+++ b/snippets/norg.json
@@ -26,7 +26,7 @@
   "link": {
     "description": "links",
     "prefix": "link",
-    "body": ["[${1:description}](${2:object})"]
+    "body": ["[${1:description}]{${2:object}}"]
   },
 
   "data": {


### PR DESCRIPTION
see neorg spec: https://github.com/nvim-neorg/norg-specs/blob/3ce2618c1469a8f09a6f0b5dec49d796b022c9ab/1.0-specification.norg#L1327