### PR TITLE
fix: Correct Verilog Module Snippet

### DIFF
--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -60,8 +60,8 @@
     "description": "Always block"
   },
   "module block": {
-    "prefix": "mod",
-    "body": ["module ${1:FILENAME} (${2})", "\n\t${0}", "\nendmoudle"],
+    "prefix": "modu",
+    "body": ["module ${1:FILENAME} (${2});", "\t${0}", "\nendmodule"],
     "description": "Module Block"
   },
   "for": {

--- a/snippets/verilog.json
+++ b/snippets/verilog.json
@@ -61,7 +61,7 @@
   },
   "module block": {
     "prefix": "modu",
-    "body": ["module ${1:FILENAME} (${2});", "\t${0}", "\nendmodule"],
+    "body": ["module ${1:FILENAME} (\n\t${2}\n);", "\t${0}", "\nendmodule"],
     "description": "Module Block"
   },
   "for": {


### PR DESCRIPTION
Updated the snippet to: 
- Correct a typo (`endmoudle` -> `endmodule`)
- Match the snippet formatting as mentioned in #216 
