### PR TITLE
Rearrange the c snippets

### DIFF
--- a/snippets/c.json
+++ b/snippets/c.json
@@ -1,113 +1,4 @@
 {
-  "for": {
-    "prefix": "for",
-    "body": [
-      "for (${1:size_t} ${2:i} = ${3:0}; $2 < ${4:length}; $2++) {",
-      "\t$0",
-      "}"
-    ],
-    "description": "Code snippet for 'for' loop"
-  },
-  "forr": {
-    "prefix": "forr",
-    "body": [
-      "for (${1:size_t} ${2:i} = ${3:length} - 1; $2 >= ${4:0}; $2--) {",
-      "\t$0",
-      "}"
-    ],
-    "description": "Code snippet for reverse 'for' loop"
-  },
-  "while": {
-    "prefix": "while",
-    "body": ["while ($1) {", "\t$0", "}"],
-    "description": ""
-  },
-  "if": {
-    "prefix": "if",
-    "body": ["if ($1) {", "\t$0", "}"],
-    "description": "Code snippet for if statement"
-  },
-  "else": {
-    "prefix": "else",
-    "body": ["else {", "\t$0", "}"],
-    "description": "Code snippet for else statement"
-  },
-  "else if": {
-    "prefix": "else if",
-    "body": ["else if ($1) {", "\t$0", "}"],
-    "description": "Code snippet for else-if statement"
-  },
-  "enum": {
-    "prefix": "enum",
-    "body": ["enum ${1:MyEnum} {", "\t$0", "};"],
-    "description": "Code snippet for enum"
-  },
-  "#ifdef": {
-    "prefix": "#ifdef",
-    "body": ["#ifdef ${1:DEBUG}", "$0", "#endif /* $1 */"],
-    "description": "Code snippet for #ifdef"
-  },
-  "#ifndef": {
-    "prefix": "#ifndef",
-    "body": ["#ifndef ${1:DEBUG}", "$0", "#endif /* !$1 */"],
-    "description": "Code snippet for #ifndef"
-  },
-  "#if": {
-    "prefix": "#if",
-    "body": ["#if ${1:0}", "$0", "#endif /* $1 */"],
-    "description": "Code snippet for #if"
-  },
-  "struct": {
-    "prefix": "struct",
-    "body": ["struct ${1:MyStruct} {", "\t$0", "};"],
-    "description": "Code snippet for struct"
-  },
-  "typedef struct": {
-    "prefix": "structt",
-    "body": ["typedef struct {", "\t$0", "} ${1:MyStruct};"],
-    "description": "Code snippet to define a type with struct"
-  },
-  "switch": {
-    "prefix": "switch",
-    "body": ["switch (${1:switch_on}) {", "\tdefault:", "\t\t$0", "\t\tbreak;", "}"],
-    "description": "Code snippet for switch statement"
-  },
-  "case": {
-    "prefix": "case",
-    "body": ["case $1:", "\t$0", "\tbreak;"],
-    "description": "Code snippet for case branch"
-  },
-  "union": {
-    "prefix": "union",
-    "body": ["union ${1:MyUnion} {", "\t$0", "};"],
-    "description": "Code snippet for union"
-  },
-  "#inc": {
-    "prefix": "#inc",
-    "body": ["#include \"$0\""],
-    "description": "Code snippet for #include \" \""
-  },
-  "#inc<": {
-    "prefix": "#inc<",
-    "body": ["#include <$0>"],
-    "description": "Code snippet for #include < >"
-  },
-  "#def": {
-    "prefix": "def",
-    "body": ["#define $0"],
-    "description": "Code snippet for #define \" \""
-  },
-  "Main function template": {
-    "prefix": "main",
-    "body": [
-      "int main (int argc, char *argv[])",
-      "{",
-      "\t$0",
-      "\treturn 0;",
-      "}"
-    ],
-    "description": "A standard main function for a C program"
-  },
   "Standard Starter Template": {
     "prefix": "sst",
     "body": [
@@ -135,22 +26,99 @@
     ],
     "description": "A standard starter template for a C program with stdlib included"
   },
+  "Main function template": {
+    "prefix": "main",
+    "body": [
+      "int main (int argc, char *argv[])",
+      "{",
+      "\t$0",
+      "\treturn 0;",
+      "}"
+    ],
+    "description": "A standard main function for a C program"
+  },
+  "#inc": {
+    "prefix": "#inc",
+    "body": ["#include \"$0\""],
+    "description": "Code snippet for #include \" \""
+  },
+  "#inc<": {
+    "prefix": "#inc<",
+    "body": ["#include <$0>"],
+    "description": "Code snippet for #include < >"
+  },
+  "#def": {
+    "prefix": "def",
+    "body": ["#define $0"],
+    "description": "Code snippet for #define \" \""
+  },
+  "#ifdef": {
+    "prefix": "#ifdef",
+    "body": ["#ifdef ${1:DEBUG}", "$0", "#endif /* $1 */"],
+    "description": "Code snippet for #ifdef"
+  },
+  "#ifndef": {
+    "prefix": "#ifndef",
+    "body": ["#ifndef ${1:DEBUG}", "$0", "#endif /* !$1 */"],
+    "description": "Code snippet for #ifndef"
+  },
+  "#if": {
+    "prefix": "#if",
+    "body": ["#if ${1:0}", "$0", "#endif /* $1 */"],
+    "description": "Code snippet for #if"
+  },
+  "if": {
+    "prefix": "if",
+    "body": ["if ($1) {", "\t$0", "}"],
+    "description": "Code snippet for if statement"
+  },
+  "else": {
+    "prefix": "else",
+    "body": ["else {", "\t$0", "}"],
+    "description": "Code snippet for else statement"
+  },
+  "else if": {
+    "prefix": "else if",
+    "body": ["else if ($1) {", "\t$0", "}"],
+    "description": "Code snippet for else-if statement"
+  },
+  "switch": {
+    "prefix": "switch",
+    "body": ["switch (${1:switch_on}) {", "\tdefault:", "\t\t$0", "\t\tbreak;", "}"],
+    "description": "Code snippet for switch statement"
+  },
+  "case": {
+    "prefix": "case",
+    "body": ["case $1:", "\t$0", "\tbreak;"],
+    "description": "Code snippet for case branch"
+  },
+  "while": {
+    "prefix": "while",
+    "body": ["while ($1) {", "\t$0", "}"],
+    "description": ""
+  },
   "Do...while loop": {
     "prefix": "do",
     "body": ["do {", "\t$1", "} while($2);"],
     "description": "Creates a do...while loop"
   },
-  "Create linked list": {
-    "prefix": "clist",
+  "for": {
+    "prefix": "for",
     "body": [
-      "typedef struct _node * Link;",
-      "typedef struct _node node;",
-      "struct _node {",
-      "\tint value;",
-      "\tLink next;",
-      "};"
+      "for (${1:size_t} ${2:i} = ${3:0}; $2 < ${4:length}; $2++) {",
+      "\t$0",
+      "}"
     ],
-    "description": "Creates a linked list template"
+    "description": "Code snippet for 'for' loop"
+  },
+  "forr": {
+    "prefix": "forr",
+    "body": [
+      "for (${1:size_t} ${2:i} = ${3:length} - 1; $2 >= ${4:0}; $2--) {",
+      "\t$0",
+      "}"
+    ],
+    "description": "Code snippet for reverse 'for' loop"
   },
   "Create a function": {
     "prefix": "func",
@@ -181,6 +149,38 @@
     "prefix": "longfunc",
     "body": ["long $1 ()", "{", "\tlong $2 = $3;$4", "\treturn $3;", "}"],
     "description": "Creates a function that returns the long type"
+  },
+  "struct": {
+    "prefix": "struct",
+    "body": ["struct ${1:MyStruct} {", "\t$0", "};"],
+    "description": "Code snippet for struct"
+  },
+  "typedef struct": {
+    "prefix": "structt",
+    "body": ["typedef struct {", "\t$0", "} ${1:MyStruct};"],
+    "description": "Code snippet to define a type with struct"
+  },
+  "enum": {
+    "prefix": "enum",
+    "body": ["enum ${1:MyEnum} {", "\t$0", "};"],
+    "description": "Code snippet for enum"
+  },
+  "union": {
+    "prefix": "union",
+    "body": ["union ${1:MyUnion} {", "\t$0", "};"],
+    "description": "Code snippet for union"
+  },
+  "Create linked list": {
+    "prefix": "clist",
+    "body": [
+      "typedef struct _node * Link;",
+      "typedef struct _node node;",
+      "struct _node {",
+      "\tint value;",
+      "\tLink next;",
+      "};"
+    ],
+    "description": "Creates a linked list template"
   },
   "Print variable of type float (2 decimal places)": {
     "prefix": "pflo",


### PR DESCRIPTION
Make the snippets order more convenient: templates, preprocessor, control flow, loops, functions, types, IO, dynamic allocation, etc.

This order is taken from [honza/vim-snippets](https://github.com/honza/vim-snippets/blob/master/snippets/c.snippets) in order to easily port some snippets from there to here.  
Also such order make it easier for the users to inspect and modify the snippets.