### PR TITLE
feat: add "do" snippet in elixir

### DIFF
--- a/snippets/elixir.json
+++ b/snippets/elixir.json
@@ -122,6 +122,14 @@
       "end"
     ]
   },
+  "do": {
+    "prefix": "do",
+    "body": [
+      "do",
+      "  $0",
+      "end"
+    ]
+  },
   "doc": {
     "prefix": "doc",
     "body": [


### PR DESCRIPTION
Hi, I add the "do" snippet for elixir.

When you try to close the "do end" block always appear the "doc" snippet because is missing the "do" snippet.