### PR TITLE
fix: fix vue/javascript wrong snippet

### DIFF
--- a/snippets/frameworks/vue/javascript.json
+++ b/snippets/frameworks/vue/javascript.json
@@ -343,7 +343,7 @@
         "body": [
             "const $1 = ($2) => {",
             "$0",
-            "});"
+            "};"
         ],
         "description": "Method composition properties to be mixed into the Vue instance. "
     },


### PR DESCRIPTION
the snippet with prefix functionVue3 in vue/javascript.json maybe wrong, there is an extra parenthesis in the code snippet