### PR TITLE
added: superscript and subscript snippets

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -376,5 +376,19 @@
       "${0}"
     ],
     "description": "Insert table with 5 rows and 5 columns. First row is heading."
+  },
+  "Insert subscript": {
+    "prefix": "sub",
+    "body": [
+      "${1}<sub>${0}"
+    ],
+    "description": "Create a subscript."
+  },
+  "Insert superscirpt": {
+    "prefix": "sup",
+    "body": [
+      "${1}<sup>${0}"
+    ],
+    "description": "Create a superscript."
   }
 }

--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -384,7 +384,7 @@
     ],
     "description": "Create a subscript."
   },
-  "Insert superscirpt": {
+  "Insert superscript": {
     "prefix": "sup",
     "body": [
       "${1}<sup>${0}"


### PR DESCRIPTION
Added superscript and subscript snippets for markdown.
Ranging from line number `380-393`.


```diff
- }
+ },
+  "Insert subscript": {
+    "prefix": "sub",
+    "body": [
+      "${1}<sub>${0}"
+    ],
+    "description": "Create a subscript."
+  },
+  "Insert superscript": {
+    "prefix": "sup",
+    "body": [
+      "${1}<sup>${0}"
+    ],
+    "description": "Create a superscript."
+  }
```