### PR TITLE
fix: golang om snippet code style

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -281,6 +281,6 @@
   },
   "if key in a map": {
 	"prefix": "om",
-	"body": "if ${1:value}, ok := ${2:map}[${3:key}]; ok == true {\n\t$4\n}"
+	"body": "if ${1:value}, ok := ${2:map}[${3:key}]; ok {\n\t$4\n}"
   }
 }


### PR DESCRIPTION
You don't need to compare bool variables with true or false, you can use `variable` or `!variable` itself.

```golang
if _, ok := map[key]; ok {

}
```

And actually this way of checking if there is key in map is more common in go than `ok == true`, see for example [this answer](https://stackoverflow.com/a/2050629).