### PR TITLE
FIX: change the `nushell` language to `nu`

### DIFF
--- a/package.json
+++ b/package.json
@@ -479,7 +479,7 @@
         "path": "./snippets/PowerShell.json"
       },
       {
-        "language": "nushell",
+        "language": "nu",
         "path": "./snippets/nushell.json"
       }
     ]


### PR DESCRIPTION
related to #285.

hello again :wave: :yum: 

actually, i do not know why i wrote this in #285, but the language of Nushell is called `nu`.
`nushell` is just the shell part of it :relieved: 

this PR fixes this typo :wink: 

cheers :yum: 