### PR TITLE
Ruby: Insert extra line after frozen_string_literal

### DIFF
--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -235,7 +235,11 @@
   },
   "Insert frozen literal string": {
     "prefix": "frozen",
-    "body": "# frozen_string_literal: true$0"
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      ""
+    ]
   },
   "Insert require": {
     "prefix": "req",

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -238,6 +238,7 @@
     "body": [
       "# frozen_string_literal: true",
       "",
+      "",
       ""
     ]
   },


### PR DESCRIPTION
When inserting `# frozen_string_literal: true`, the cursor is at the end of the line. While it isn't set in stone, it's pretty much a standard.

With the change I'd like that the cursor is two lines below, as in:
```
# frozen_string_literal: true

$here
```
Is `""` the right way to add extra lines?

Would that be ok? In my particular case this extra annoying because `<Enter>` extends the comment section.