### PR TITLE
add hints for Markdown links and images

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -31,7 +31,7 @@
   },
   "Links": {
     "prefix": ["l", "link"],
-    "body": ["[${1}](${2}) ${0}"],
+    "body": ["[${1:text}](${2:url}) ${0}"],
     "description": "Add links"
   },
   "URLS": {
@@ -41,7 +41,7 @@
   },
   "Images": {
     "prefix": "img",
-    "body": ["![${1}](${2}) ${0}"],
+    "body": ["![${1:alt text}](${2:path}) ${0}"],
     "description": "Add images"
   },
   "Insert strikethrough": {


### PR DESCRIPTION
Snippets for Markdown links and images currently lack input hints. In the case of a link:

```
[]()
```

Hints can be added to distinguish where you insert the text, and where you insert the URL.

With hints, the link snippet look like this:

```
[text](url)
```
And the image snippet like so:

```
![alt text](path)
```