### PR TITLE
feat(csharp) language-specification/documentation-comments

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -1,401 +1,661 @@
 {
-    "Attribute using recommended pattern": {
-        "prefix": "attribute",
-        "body": [
-            "[System.AttributeUsage(System.AttributeTargets.${1:All}, Inherited = ${2:false}, AllowMultiple = ${3:true})]",
-            "sealed class ${4:My}Attribute : System.Attribute",
-            "{",
-            "    // See the attribute guidelines at",
-            "    //  http://go.microsoft.com/fwlink/?LinkId=85236",
-            "    readonly string positionalString;",
-            "    ",
-            "    // This is a positional argument",
-            "    public ${4:My}Attribute(string positionalString)",
-            "    {",
-            "        this.positionalString = positionalString;",
-            "        ",
-            "        // TODO: Implement code here",
-            "        ${5:throw new System.NotImplementedException();}",
-            "    }",
-            "    ",
-            "    public string PositionalString",
-            "    {",
-            "        get { return positionalString; }",
-            "    }",
-            "    ",
-            "    // This is a named argument",
-            "    public int NamedInt { get; set; }",
-            "}"
-        ],
-        "description": "Attribute using recommended pattern"
-    },
-    "Checked block": {
-        "prefix": "checked",
-        "body": ["checked", "{", "    $0", "}"],
-        "description": "Checked block"
-    },
-    "Class": {
-        "prefix": "class",
-        "body": ["class ${1:Name}", "{", "    $0", "}"],
-        "description": "Class"
-    },
-    "Console.WriteLine": {
-        "prefix": "cw",
-        "body": ["System.Console.WriteLine($0);"],
-        "description": "Console.WriteLine"
-    },
-    "do...while loop": {
-        "prefix": "do",
-        "body": ["do", "{", "    $0", "} while (${1:true});"],
-        "description": "do...while loop"
-    },
-    "Else statement": {
-        "prefix": "else",
-        "body": ["else", "{", "    $0", "}"],
-        "description": "Else statement"
-    },
-    "Enum": {
-        "prefix": "enum",
-        "body": ["enum ${1:Name}", "{", "    $0", "}"],
-        "description": "Enum"
-    },
-    "Implementing Equals() according to guidelines": {
-        "prefix": "equals",
-        "body": [
-            "// override object.Equals",
-            "public override bool Equals(object obj)",
-            "{",
-            "    //",
-            "    // See the full list of guidelines at",
-            "    //   http://go.microsoft.com/fwlink/?LinkID=85237",
-            "    // and also the guidance for operator== at",
-            "    //   http://go.microsoft.com/fwlink/?LinkId=85238",
-            "    //",
-            "    ",
-            "    if (obj == null || GetType() != obj.GetType())",
-            "    {",
-            "        return false;",
-            "    }",
-            "    ",
-            "    // TODO: write your implementation of Equals() here",
-            "    ${1:throw new System.NotImplementedException();}",
-            "    return base.Equals (obj);",
-            "}",
-            "",
-            "// override object.GetHashCode",
-            "public override int GetHashCode()",
-            "{",
-            "    // TODO: write your implementation of GetHashCode() here",
-            "    ${2:throw new System.NotImplementedException();}",
-            "    return base.GetHashCode();",
-            "}"
-        ],
-        "description": "Implementing Equals() according to guidelines"
-    },
-    "Exception": {
-        "prefix": "exception",
-        "body": [
-            "[System.Serializable]",
-            "public class ${1:My}Exception : ${2:System.Exception}",
-            "{",
-            "    public ${1:My}Exception() { }",
-            "    public ${1:My}Exception(string message) : base(message) { }",
-            "    public ${1:My}Exception(string message, System.Exception inner) : base(message, inner) { }",
-            "    protected ${1:My}Exception(",
-            "        System.Runtime.Serialization.SerializationInfo info,",
-            "        System.Runtime.Serialization.StreamingContext context) : base(info, context) { }",
-            "}"
-        ],
-        "description": "Exception"
-    },
-    "Foreach statement": {
-        "prefix": "foreach",
-        "body": [
-            "foreach (${1:var} ${2:item} in ${3:collection})",
-            "{",
-            "    $0",
-            "}"
-        ],
-        "description": "Foreach statement"
-    },
-    "Reverse for loop": {
-        "prefix": "forr",
-        "body": [
-            "for (int ${1:i} = ${2:length} - 1; ${1:i} >= 0 ; ${1:i}--)",
-            "{",
-            "    $0",
-            "}"
-        ],
-        "description": "Reverse for loop"
-    },
-    "for loop": {
-        "prefix": "for",
-        "body": [
-            "for (int ${1:i} = 0; ${1:i} < ${2:length}; ${1:i}++)",
-            "{",
-            "    $0",
-            "}"
-        ],
-        "description": "for loop"
-    },
-    "if statement": {
-        "prefix": "if",
-        "body": ["if (${1:true})", "{", "    $0", "}"],
-        "description": "if statement"
-    },
-    "else-if statement": {
-        "prefix": "else if",
-        "body": ["else if (${1:true})", "{", "    $0", "}"],
-        "description": "else-if statement"
-    },
-    "Indexer": {
-        "prefix": "indexer",
-        "body": [
-            "${1:public} ${2:object} this[${3:int} index]",
-            "{",
-            "    get { $4 }",
-            "    set { $0 }",
-            "}"
-        ],
-        "description": "Indexer"
-    },
-    "Interface": {
-        "prefix": "interface",
-        "body": ["interface I${1:Name}", "{", "    $0", "}"],
-        "description": "Interface"
-    },
-    "Safely invoking an event": {
-        "prefix": "invoke",
-        "body": [
-            "${1:EventHandler} temp = ${2:MyEvent};",
-            "if (temp != null)",
-            "{",
-            "    temp($0);",
-            "}"
-        ],
-        "description": "Safely invoking an event"
-    },
-    "Simple iterator": {
-        "prefix": "iterator",
-        "body": [
-            "public System.Collections.Generic.IEnumerator<${1:ElementType}> GetEnumerator()",
-            "{",
-            "    $0throw new System.NotImplementedException();",
-            "    yield return default(${1:ElementType});",
-            "}"
-        ],
-        "description": "Simple iterator"
-    },
-    "Named iterator/indexer pair using a nested class": {
-        "prefix": "iterindex",
-        "body": [
-            "public ${1:Name}Iterator ${1:Name}",
-            "{",
-            "    get",
-            "    {",
-            "        return new ${1:Name}Iterator(this);",
-            "    }",
-            "}",
-            "",
-            "public class ${1:Name}Iterator",
-            "{",
-            "    readonly ${2:ClassName} outer;",
-            "    ",
-            "    internal ${1:Name}Iterator(${2:ClassName} outer)",
-            "    {",
-            "        this.outer = outer;",
-            "    }",
-            "    ",
-            "    // TODO: provide an appropriate implementation here",
-            "    public int Length { get { return 1; } }",
-            "    ",
-            "    public ${3:ElementType} this[int index]",
-            "    {",
-            "        get",
-            "        {",
-            "            //",
-            "            // TODO: implement indexer here",
-            "            //",
-            "            // you have full access to ${2:ClassName} privates",
-            "            //",
-            "            ${4:throw new System.NotImplementedException();}",
-            "            return default(${3:ElementType});",
-            "        }",
-            "    }",
-            "    ",
-            "    public System.Collections.Generic.IEnumerator<${3:ElementType}> GetEnumerator()",
-            "    {",
-            "        for (int i = 0; i < this.Length; i++)",
-            "        {",
-            "            yield return this[i];",
-            "        }",
-            "    }",
-            "}"
-        ],
-        "description": "Named iterator/indexer pair using a nested class"
-    },
-    "Lock statement": {
-        "prefix": "lock",
-        "body": ["lock (${1:this})", "{", "    $0", "}"],
-        "description": "Lock statement"
-    },
-    "MessageBox.Show": {
-        "prefix": "mbox",
-        "body": ["System.Windows.Forms.MessageBox.Show(\"${1:Text}\");$0"],
-        "description": "MessageBox.Show"
-    },
-    "Namespace": {
-        "prefix": "namespace",
-        "body": ["namespace ${1:Name}", "{", "    $0", "}"],
-        "description": "Namespace"
-    },
-    "#if": {
-        "prefix": "ifd",
-        "body": ["#if ${1:true}", "    $0", "#endif"],
-        "description": "#if"
-    },
-    "#region": {
-        "prefix": "region",
-        "body": ["#region ${1:Name}", "    $0", "#endregion"],
-        "description": "#region"
-    },
-    "Property and backing field": {
-        "prefix": "propfull",
-        "body": [
-            "private ${1:int} ${2:myVar};",
-            "public ${1:int} ${3:MyProperty}",
-            "{",
-            "    get { return ${2:myVar}; }",
-            "    set { ${2:myVar} = value; }",
-            "}",
-            "$0"
-        ],
-        "description": "Property and backing field"
-    },
-    "propg": {
-        "prefix": "propg",
-        "body": ["public ${1:int} ${2:MyProperty} { get; private set; }$0"],
-        "description": "An automatically implemented property with a 'get' accessor and a private 'set' accessor. C# 3.0 or higher"
-    },
-    "prop": {
-        "prefix": "prop",
-        "body": ["public ${1:int} ${2:MyProperty} { get; set; }$0"],
-        "description": "An automatically implemented property. C# 3.0 or higher"
-    },
-    "sim": {
-        "prefix": "sim",
-        "body": [
-            "static int Main(string[] args)",
-            "{",
-            "    $0",
-            "    return 0;",
-            "}"
-        ],
-        "description": "int Main()"
-    },
-    "Struct": {
-        "prefix": "struct",
-        "body": ["struct ${1:Name}", "{", "    $0", "}"],
-        "description": "Struct"
-    },
-    "svm": {
-        "prefix": "svm",
-        "body": ["static void Main(string[] args)", "{", "    $0", "}"],
-        "description": "void Main()"
-    },
-    "Switch statement": {
-        "prefix": "switch",
-        "body": ["switch (${1:switch_on})", "{", "    $0", "    default:", "}"],
-        "description": "Switch statement"
-    },
-    "Try finally": {
-        "prefix": "tryf",
-        "body": ["try", "{", "    $1", "}", "finally", "{", "    $0", "}"],
-        "description": "Try finally"
-    },
-    "Try catch": {
-        "prefix": "try",
-        "body": [
-            "try",
-            "{",
-            "    $1",
-            "}",
-            "catch (${2:System.Exception})",
-            "{",
-            "    $0",
-            "    throw;",
-            "}"
-        ],
-        "description": "Try catch"
-    },
-    "Unchecked block": {
-        "prefix": "unchecked",
-        "body": ["unchecked", "{", "    $0", "}"],
-        "description": "Unchecked block"
-    },
-    "Unsafe statement": {
-        "prefix": "unsafe",
-        "body": ["unsafe", "{", "    $0", "}"],
-        "description": "Unsafe statement"
-    },
-    "Using statement": {
-        "prefix": "using",
-        "body": ["using (${1:resource})", "{", "    $0", "}"],
-        "description": "Using statement"
-    },
-    "While loop": {
-        "prefix": "while",
-        "body": ["while (${1:true})", "{", "    $0", "}"],
-        "description": "While loop"
-    },
-    "constructor": {
-        "prefix": "ctor",
-        "body": [
-            "${1:public} ${2:$TM_FILENAME_BASE}(${3:Parameters})",
-            "{",
-            "    $0",
-            "}"
-        ],
-        "description": "constructor"
-    },
-    "xUnit Test": {
-        "prefix": "fact",
-        "body": [
-            "[Fact]",
-            "public void ${1:TestName}()",
-            "{",
-            "//Given",
-            "",
-            "//When",
-            "",
-            "//Then",
-            "}$0"
-        ],
-        "description": "create xunit test method"
-    },
-    "Creates a Method structure": {
-        "prefix": "method",
-        "body": [
-            "${1:public} ${2:void} ${3:MyMethod}(${4:string} ${5:parameter})",
-            "{",
-            "\t$0",
-            "}"
-        ],
-        "description": "Creates a Method structure"
-    },
-    "Creates an Async Method structure": {
-        "prefix": "method_async",
-        "body": [
-            "${1:public} async ${2:Task}<${3:object}> ${4:MyMethodAsync}(${5:string} ${6:parameter})",
-            "{",
-            "\t$0",
-            "}"
-        ],
-        "description": "Creates an async Method structure"
-    },
-    "cls": {
-        "prefix": "cls",
-        "body": ["${1:public} class ${2:$TM_FILENAME_BASE}", "{", "\t$0", "}"],
-        "description": "Create new class"
-    }
+  "Attribute using recommended pattern": {
+    "prefix": "attribute",
+    "body": [
+      "[System.AttributeUsage(System.AttributeTargets.${1:All}, Inherited = ${2:false}, AllowMultiple = ${3:true})]",
+      "sealed class ${4:My}Attribute : System.Attribute",
+      "{",
+      "    // See the attribute guidelines at",
+      "    //  http://go.microsoft.com/fwlink/?LinkId=85236",
+      "    readonly string positionalString;",
+      "    ",
+      "    // This is a positional argument",
+      "    public ${4:My}Attribute(string positionalString)",
+      "    {",
+      "        this.positionalString = positionalString;",
+      "        ",
+      "        // TODO: Implement code here",
+      "        ${5:throw new System.NotImplementedException();}",
+      "    }",
+      "    ",
+      "    public string PositionalString",
+      "    {",
+      "        get { return positionalString; }",
+      "    }",
+      "    ",
+      "    // This is a named argument",
+      "    public int NamedInt { get; set; }",
+      "}"
+    ],
+    "description": "Attribute using recommended pattern"
+  },
+  "Checked block": {
+    "prefix": "checked",
+    "body": [
+      "checked",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Checked block"
+  },
+  "Class": {
+    "prefix": "class",
+    "body": [
+      "class ${1:Name}",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Class"
+  },
+  "Console.WriteLine": {
+    "prefix": "cw",
+    "body": [
+      "System.Console.WriteLine($0);"
+    ],
+    "description": "Console.WriteLine"
+  },
+  "do...while loop": {
+    "prefix": "do",
+    "body": [
+      "do",
+      "{",
+      "    $0",
+      "} while (${1:true});"
+    ],
+    "description": "do...while loop"
+  },
+  "Else statement": {
+    "prefix": "else",
+    "body": [
+      "else",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Else statement"
+  },
+  "Enum": {
+    "prefix": "enum",
+    "body": [
+      "enum ${1:Name}",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Enum"
+  },
+  "Implementing Equals() according to guidelines": {
+    "prefix": "equals",
+    "body": [
+      "// override object.Equals",
+      "public override bool Equals(object obj)",
+      "{",
+      "    //",
+      "    // See the full list of guidelines at",
+      "    //   http://go.microsoft.com/fwlink/?LinkID=85237",
+      "    // and also the guidance for operator== at",
+      "    //   http://go.microsoft.com/fwlink/?LinkId=85238",
+      "    //",
+      "    ",
+      "    if (obj == null || GetType() != obj.GetType())",
+      "    {",
+      "        return false;",
+      "    }",
+      "    ",
+      "    // TODO: write your implementation of Equals() here",
+      "    ${1:throw new System.NotImplementedException();}",
+      "    return base.Equals (obj);",
+      "}",
+      "",
+      "// override object.GetHashCode",
+      "public override int GetHashCode()",
+      "{",
+      "    // TODO: write your implementation of GetHashCode() here",
+      "    ${2:throw new System.NotImplementedException();}",
+      "    return base.GetHashCode();",
+      "}"
+    ],
+    "description": "Implementing Equals() according to guidelines"
+  },
+  "Exception": {
+    "prefix": "exception",
+    "body": [
+      "[System.Serializable]",
+      "public class ${1:My}Exception : ${2:System.Exception}",
+      "{",
+      "    public ${1:My}Exception() { }",
+      "    public ${1:My}Exception(string message) : base(message) { }",
+      "    public ${1:My}Exception(string message, System.Exception inner) : base(message, inner) { }",
+      "    protected ${1:My}Exception(",
+      "        System.Runtime.Serialization.SerializationInfo info,",
+      "        System.Runtime.Serialization.StreamingContext context) : base(info, context) { }",
+      "}"
+    ],
+    "description": "Exception"
+  },
+  "Foreach statement": {
+    "prefix": "foreach",
+    "body": [
+      "foreach (${1:var} ${2:item} in ${3:collection})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Foreach statement"
+  },
+  "Reverse for loop": {
+    "prefix": "forr",
+    "body": [
+      "for (int ${1:i} = ${2:length} - 1; ${1:i} >= 0 ; ${1:i}--)",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Reverse for loop"
+  },
+  "for loop": {
+    "prefix": "for",
+    "body": [
+      "for (int ${1:i} = 0; ${1:i} < ${2:length}; ${1:i}++)",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "for loop"
+  },
+  "if statement": {
+    "prefix": "if",
+    "body": [
+      "if (${1:true})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "if statement"
+  },
+  "else-if statement": {
+    "prefix": "else if",
+    "body": [
+      "else if (${1:true})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "else-if statement"
+  },
+  "Indexer": {
+    "prefix": "indexer",
+    "body": [
+      "${1:public} ${2:object} this[${3:int} index]",
+      "{",
+      "    get { $4 }",
+      "    set { $0 }",
+      "}"
+    ],
+    "description": "Indexer"
+  },
+  "Interface": {
+    "prefix": "interface",
+    "body": [
+      "interface I${1:Name}",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Interface"
+  },
+  "Safely invoking an event": {
+    "prefix": "invoke",
+    "body": [
+      "${1:EventHandler} temp = ${2:MyEvent};",
+      "if (temp != null)",
+      "{",
+      "    temp($0);",
+      "}"
+    ],
+    "description": "Safely invoking an event"
+  },
+  "Simple iterator": {
+    "prefix": "iterator",
+    "body": [
+      "public System.Collections.Generic.IEnumerator<${1:ElementType}> GetEnumerator()",
+      "{",
+      "    $0throw new System.NotImplementedException();",
+      "    yield return default(${1:ElementType});",
+      "}"
+    ],
+    "description": "Simple iterator"
+  },
+  "Named iterator/indexer pair using a nested class": {
+    "prefix": "iterindex",
+    "body": [
+      "public ${1:Name}Iterator ${1:Name}",
+      "{",
+      "    get",
+      "    {",
+      "        return new ${1:Name}Iterator(this);",
+      "    }",
+      "}",
+      "",
+      "public class ${1:Name}Iterator",
+      "{",
+      "    readonly ${2:ClassName} outer;",
+      "    ",
+      "    internal ${1:Name}Iterator(${2:ClassName} outer)",
+      "    {",
+      "        this.outer = outer;",
+      "    }",
+      "    ",
+      "    // TODO: provide an appropriate implementation here",
+      "    public int Length { get { return 1; } }",
+      "    ",
+      "    public ${3:ElementType} this[int index]",
+      "    {",
+      "        get",
+      "        {",
+      "            //",
+      "            // TODO: implement indexer here",
+      "            //",
+      "            // you have full access to ${2:ClassName} privates",
+      "            //",
+      "            ${4:throw new System.NotImplementedException();}",
+      "            return default(${3:ElementType});",
+      "        }",
+      "    }",
+      "    ",
+      "    public System.Collections.Generic.IEnumerator<${3:ElementType}> GetEnumerator()",
+      "    {",
+      "        for (int i = 0; i < this.Length; i++)",
+      "        {",
+      "            yield return this[i];",
+      "        }",
+      "    }",
+      "}"
+    ],
+    "description": "Named iterator/indexer pair using a nested class"
+  },
+  "Lock statement": {
+    "prefix": "lock",
+    "body": [
+      "lock (${1:this})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Lock statement"
+  },
+  "MessageBox.Show": {
+    "prefix": "mbox",
+    "body": [
+      "System.Windows.Forms.MessageBox.Show(\"${1:Text}\");$0"
+    ],
+    "description": "MessageBox.Show"
+  },
+  "Namespace": {
+    "prefix": "namespace",
+    "body": [
+      "namespace ${1:Name}",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Namespace"
+  },
+  "#if": {
+    "prefix": "ifd",
+    "body": [
+      "#if ${1:true}",
+      "    $0",
+      "#endif"
+    ],
+    "description": "#if"
+  },
+  "#region": {
+    "prefix": "region",
+    "body": [
+      "#region ${1:Name}",
+      "    $0",
+      "#endregion"
+    ],
+    "description": "#region"
+  },
+  "Property and backing field": {
+    "prefix": "propfull",
+    "body": [
+      "private ${1:int} ${2:myVar};",
+      "public ${1:int} ${3:MyProperty}",
+      "{",
+      "    get { return ${2:myVar}; }",
+      "    set { ${2:myVar} = value; }",
+      "}",
+      "$0"
+    ],
+    "description": "Property and backing field"
+  },
+  "propg": {
+    "prefix": "propg",
+    "body": [
+      "public ${1:int} ${2:MyProperty} { get; private set; }$0"
+    ],
+    "description": "An automatically implemented property with a 'get' accessor and a private 'set' accessor. C# 3.0 or higher"
+  },
+  "prop": {
+    "prefix": "prop",
+    "body": [
+      "public ${1:int} ${2:MyProperty} { get; set; }$0"
+    ],
+    "description": "An automatically implemented property. C# 3.0 or higher"
+  },
+  "sim": {
+    "prefix": "sim",
+    "body": [
+      "static int Main(string[] args)",
+      "{",
+      "    $0",
+      "    return 0;",
+      "}"
+    ],
+    "description": "int Main()"
+  },
+  "Struct": {
+    "prefix": "struct",
+    "body": [
+      "struct ${1:Name}",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Struct"
+  },
+  "svm": {
+    "prefix": "svm",
+    "body": [
+      "static void Main(string[] args)",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "void Main()"
+  },
+  "Switch statement": {
+    "prefix": "switch",
+    "body": [
+      "switch (${1:switch_on})",
+      "{",
+      "    $0",
+      "    default:",
+      "}"
+    ],
+    "description": "Switch statement"
+  },
+  "Try finally": {
+    "prefix": "tryf",
+    "body": [
+      "try",
+      "{",
+      "    $1",
+      "}",
+      "finally",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Try finally"
+  },
+  "Try catch": {
+    "prefix": "try",
+    "body": [
+      "try",
+      "{",
+      "    $1",
+      "}",
+      "catch (${2:System.Exception})",
+      "{",
+      "    $0",
+      "    throw;",
+      "}"
+    ],
+    "description": "Try catch"
+  },
+  "Unchecked block": {
+    "prefix": "unchecked",
+    "body": [
+      "unchecked",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Unchecked block"
+  },
+  "Unsafe statement": {
+    "prefix": "unsafe",
+    "body": [
+      "unsafe",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Unsafe statement"
+  },
+  "Using statement": {
+    "prefix": "using",
+    "body": [
+      "using (${1:resource})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "Using statement"
+  },
+  "While loop": {
+    "prefix": "while",
+    "body": [
+      "while (${1:true})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "While loop"
+  },
+  "constructor": {
+    "prefix": "ctor",
+    "body": [
+      "${1:public} ${2:$TM_FILENAME_BASE}(${3:Parameters})",
+      "{",
+      "    $0",
+      "}"
+    ],
+    "description": "constructor"
+  },
+  "xUnit Test": {
+    "prefix": "fact",
+    "body": [
+      "[Fact]",
+      "public void ${1:TestName}()",
+      "{",
+      "//Given",
+      "",
+      "//When",
+      "",
+      "//Then",
+      "}$0"
+    ],
+    "description": "create xunit test method"
+  },
+  "Creates a Method structure": {
+    "prefix": "method",
+    "body": [
+      "${1:public} ${2:void} ${3:MyMethod}(${4:string} ${5:parameter})",
+      "{",
+      "\t$0",
+      "}"
+    ],
+    "description": "Creates a Method structure"
+  },
+  "Creates an Async Method structure": {
+    "prefix": "method_async",
+    "body": [
+      "${1:public} async ${2:Task}<${3:object}> ${4:MyMethodAsync}(${5:string} ${6:parameter})",
+      "{",
+      "\t$0",
+      "}"
+    ],
+    "description": "Creates an async Method structure"
+  },
+  "cls": {
+    "prefix": "cls",
+    "body": [
+      "${1:public} class ${2:$TM_FILENAME_BASE}",
+      "{",
+      "\t$0",
+      "}"
+    ],
+    "description": "Create new class"
+  },
+  "comment": {
+    "prefix": "///",
+    "body": [
+      "/// <summary>",
+      "/// ${1:What it does.}",
+      "/// </summary>",
+      "/// <param>Example parameter.</param>",
+      "/// <returns>${2:Something.}</returns>",
+      "/// <example>Write me later.</example>"
+    ],
+    "description": "A C# comment with description, parameters, return, and example."
+  },
+  "<c>": {
+    "prefix": "<c>",
+    "body": [
+      "<c>${1:text.}<c>"
+    ],
+    "description": "This tag provides a mechanism to indicate that a fragment of text within a description should be set in a special font such as that used for a block of code. For lines of actual code, use <code>."
+  },
+  "<code>": {
+    "prefix": "<code>",
+    "body": [
+      "<code>${1:source code or program output.}<code>"
+    ],
+    "description": "This tag is used to set one or more lines of source code or program output in some special font. For small code fragments in narrative, use <c>."
+  },
+  "<example>": {
+    "prefix": "<example>",
+    "body": [
+      "<example>${1:description.}<example>"
+    ],
+    "description": "This tag allows example code within a comment, to specify how a method or other library member might be used. Ordinarily, this would also involve use of the tag <code> as well."
+  },
+  "<exception>": {
+    "prefix": "<exception>",
+    "body": [
+      "<exception cref=\"${1]:ExceptionName}\">${2:description.}<exception>"
+    ],
+    "description": "This tag provides a way to document the exceptions a method can throw. cref=\"member\" is the name of the exceptionh, which should be a member. The documentation generator checks that the given member exists and translates member to the canonical element name in the documentation file. Description is a description of the circumstances in which the exception is thrown."
+  },
+  "<include>": {
+    "prefix": "<include>",
+    "body": [
+      "<include file=\"${1]:filename}\" path=\"${2:xpath}\"/>"
+    ],
+    "description": "This tag allows including information from an XML document that is external to the source code file. The external file must be a well-formed XML document, and an XPath expression is applied to that document to specify what XML from that document to include. The <include> tag is then replaced with the selected XML from the external document. Note this is a self closing tag."
+  },
+  "<list>": {
+    "prefix": "<list>",
+    "body": [
+      "<list type=\"bullet\">",
+      "<item>",
+      "<description>${1:Item 1.}</description>",
+      "<description>${2:Item 2.}</description>",
+      "<description>${3:Item 3.}</description>",
+      "</item>",
+      "</list>"
+    ],
+    "description": "This tag is used to create a list or table of items. It can contain a <listheader> block to define the heading row of either a table or definition list. (When defining a table, only an entry for term in the heading need be supplied.)\n\nEach item in the list is specified with an <item> block. When creating a definition list, both term and description must be specified. However, for a table, bulleted list, or numbered list, only description need be specified."
+  },
+  "<para>": {
+    "prefix": "<para>",
+    "body": [
+      "<para>${1:content.}</para>"
+    ],
+    "description": "Adds a paragraph. This tag is for use inside other tags, such as <summary> (§D.3.16) or <returns> (§D.3.13), and permits structure to be added to text."
+  },
+  "<param>": {
+    "prefix": "<param>",
+    "body": [
+      "<param name=\"${1:name}\">${2:description.}</param>"
+    ],
+    "description": "This tag is used to describe a parameter for a method, constructor, or indexer."
+  },
+  "<paramref>": {
+    "prefix": "<paramref>",
+    "body": [
+      "<paramref name=\"${1:name}\"/>"
+    ],
+    "description": "This tag is used to indicate that a word is a parameter. The documentation file can be processed to format this parameter in some distinct way."
+  },
+  "<permission>": {
+    "prefix": "<permission>",
+    "body": [
+      "<permission cref=\"${1:member}\">${2:description.}</permission>"
+    ],
+    "description": "This tag allows the security accessibility of a member to be documented."
+  },
+  "<remarks>": {
+    "prefix": "<remarks>",
+    "body": [
+      "<remarks>${1:description.}</remarks>"
+    ],
+    "description": "This tag is used to specify extra information about a type. Use <summary> to describe the type itself and the members of a type."
+  },
+  "<returns>": {
+    "prefix": "<returns>",
+    "body": [
+      "<returns>${1:description.}</returns>"
+    ],
+    "description": "This tag is used to describe the return value of a method."
+  },
+  "<see>": {
+    "prefix": "<see>",
+    "body": [
+      "<see cref=\"${1:member}\" href=\"${2:url}\" langword=\"${3:keyword}\"/>"
+    ],
+    "description": "This tag allows a link to be specified within text. Use <seealso> to indicate text that is to appear in a See Also subclause."
+  },
+  "<seealso>": {
+    "prefix": "<seealso>",
+    "body": [
+      "<seealso cref=\"${1:member}\" href=\"${2:url}\"/>"
+    ],
+    "description": "This tag allows an entry to be generated for the See Also subclause. Use <see> to specify a link from within text."
+  },
+  "<summary>": {
+    "prefix": "<summary>",
+    "body": [
+      "<summary>${1:description.}</summary>"
+    ],
+    "description": "This tag can be used to describe a type or a member of a type. Use <remarks> to describe the type itself."
+  },
+  "<typeparam>": {
+    "prefix": "<typeparam>",
+    "body": [
+      "<typeparam name=\"${1:name}\">${2:description.}</typeparam>"
+    ],
+    "description": "This tag is used to describe a type parameter for a generic type or method."
+  },
+  "<typeparamref>": {
+    "prefix": "<typeparamref>",
+    "body": [
+      "<typeparamref name=\"${1:description}\">${2:description.}</typeparamref>"
+    ],
+    "description": "This tag is used to indicate that a word is a type parameter. The documentation file can be processed to format this type parameter in some distinct way."
+  },
+  "<value>": {
+    "prefix": "<value>",
+    "body": [
+      "<value>${1:description.}</value>"
+    ],
+    "description": "This tag allows a property to be described."
+  }
 }

--- a/snippets/javascript/jsdoc.json
+++ b/snippets/javascript/jsdoc.json
@@ -1,61 +1,630 @@
 {
-    "JSDoc Comment": {
-        "prefix": "/*",
-        "body": ["/**\n", " * ${1:Comment}$0\n", "*/"],
-        "description": "A JSDoc comment"
-    },
-    "author email": {
-        "prefix": "@au",
-        "body": ["@author ${1:author_name} [${2:author_email}]"],
-        "description": "@author email (First Last)"
-    },
-    "Lisense desc": {
-        "prefix": "@li",
-        "body": ["@license ${1:MIT}$0"],
-        "description": "@lisence Description"
-    },
-    "Semantic version": {
-        "prefix": "@ver",
-        "body": ["@version ${1:0.1.0}$0"],
-        "description": "@version Semantic version"
-    },
-    "File overview": {
-        "prefix": "@fileo",
+    "comment": {
+        "prefix": "/**",
         "body": [
-            "/**\n",
-            " * @fileoverview ${1:Description_of_the_file}$0",
+            "/**",
+            " * ${1:What it does}$0.",
+            " *",
+            " * @param a - Example parameter.",
+            " * @returns ${2:Something}$0.",
+            " *",
+            " * @example",
+            " * ```",
+            " * write me later",
+            " * ```",
             "*/"
         ],
-        "description": "@fileoverview Description"
+        "description": "A full JSDoc comment with description, parameters, return, and example."
     },
-    "Contructor": {
-        "prefix": "@constr",
-        "body": ["@contructor"],
-        "description": "@constructor"
+    "comment simple": {
+        "prefix": "/*",
+        "body": [
+            "/**",
+            " * ${1:Comment}$0",
+            "*/"
+        ],
+        "description": "A simpple JSDoc comment."
     },
-    "varname": {
-        "prefix": "@p",
-        "body": ["@param ${1:Type} ${2:varname} ${3:Description}"],
-        "description": "@param {Type} varname Description"
+    "abstract": {
+        "prefix": "@abstract",
+        "body": [
+            "@abstract"
+        ],
+        "description": "This member must be implemented (or overridden) by the inheritor. Synonysm of @virtual."
     },
-    "return type desc": {
-        "prefix": "@ret",
-        "body": ["@return ${1:Type} ${2:Description}"],
-        "description": "@return {Type} Description"
+    "virtual": {
+        "prefix": "@virtual",
+        "body": [
+            "@virlual"
+        ],
+        "description": "This member must be implemented (or overridden) by the inheritor. Synonysm of @abstract."
     },
-    "private": {
-        "prefix": "@pri",
-        "body": ["@private"],
-        "description": "@private"
+    "access": {
+        "prefix": "@access",
+        "body": [
+            "@access ${1:private}$0"
+        ],
+        "description": "Specify the access level of this member (private, package-private, public, or protected)."
+    },
+    "alias": {
+        "prefix": "@alias",
+        "body": [
+            "@alias ${1:name}$0"
+        ],
+        "description": "Treat a member as if it had a different name."
+    },
+    "async": {
+        "prefix": "@async",
+        "body": [
+            "@async"
+        ],
+        "description": "Indicate that the function is asynchronous."
+    },
+    "augments": {
+        "prefix": "@augments",
+        "body": [
+            "@augments ${1:namepath}"
+        ],
+        "description": "The @augments or @extends tag indicates that a symbol inherits from, and potentially adds to, a parent symbol. You can use this tag to document both class-based and prototype-based inheritance. Synonysm of @extends."
+    },
+    "extends": {
+        "prefix": "@extends",
+        "body": [
+            "@extends ${1:namepath}"
+        ],
+        "description": "The @augments or @extends tag indicates that a symbol inherits from, and potentially adds to, a parent symbol. You can use this tag to document both class-based and prototype-based inheritance. Synonysm of @augments."
+    },
+    "author": {
+        "prefix": "@author",
+        "body": [
+            "@author ${1:author_name} <${2:author_email}>"
+        ],
+        "description": "Identify the author of an item."
+    },
+    "borrows": {
+        "prefix": "@borrows",
+        "body": [
+            "@borrows ${1:that namepath} as ${1:this namepath}"
+        ],
+        "description": "The @borrows tag allows you to add documentation for another symbol to your documentation. This tag would be useful if you had more than one way to reference a function, but you didn't want to duplicate the same documentation in two places."
+    },
+    "callback": {
+        "prefix": "@callback",
+        "body": [
+            "@callback ${1:namepath}"
+        ],
+        "description": "The @callback tag provides information about a callback function that can be passed to other functions, including the callback's parameters and return value. You can include any of the tags that you can provide for a @method."
+    },
+    "class": {
+        "prefix": "@class",
+        "body": [
+            "@class"
+        ],
+        "description": "This function is intended to be called with the \"new\" keyword. Synonysm of @constructor."
+    },
+    "constructor": {
+        "prefix": "@constructor",
+        "body": [
+            "@constructor"
+        ],
+        "description": "This function is intended to be called with the \"new\" keyword. Synonysm of @class."
+    },
+    "classdesc": {
+        "prefix": "@classdesc",
+        "body": [
+            "@classdesc ${1:some description}"
+        ],
+        "description": "Use the following text to describe the entire class."
+    },
+    "constant": {
+        "prefix": "@constant",
+        "body": [
+            "@constant"
+        ],
+        "description": "Document an object as a constant. Synonysm of @const."
+    },
+    "constructs": {
+        "prefix": "@constructs",
+        "body": [
+            "@constructs"
+        ],
+        "description": "This function member will be the constructor for the previous class."
+    },
+    "copyright": {
+        "prefix": "@copyright",
+        "body": [
+            "@copyright ${1:some copyright text}"
+        ],
+        "description": "Document some copyright information."
+    },
+    "default": {
+        "prefix": "@default",
+        "body": [
+            "@default"
+        ],
+        "description": "The @default tag allows you to document the assigned value of a symbol. You can supply this tag with a value yourself or you can allow JSDoc to automatically document the value from the source code -- only possible when the documented symbol is being assigned a single, simple value that is either: a string, a number, a boolean or null. Synonysm of @defaultvalue."
+    },
+    "defaultvalue": {
+        "prefix": "@defaultvalue",
+        "body": [
+            "@defaultvalue"
+        ],
+        "description": "The @default tag allows you to document the assigned value of a symbol. You can supply this tag with a value yourself or you can allow JSDoc to automatically document the value from the source code -- only possible when the documented symbol is being assigned a single, simple value that is either: a string, a number, a boolean or null. Synonysm of @default."
+    },
+    "deprecated": {
+        "prefix": "@deprecated",
+        "body": [
+            "@deprecated"
+        ],
+        "description": "Document that this is no longer the preferred way."
+    },
+    "description": {
+        "prefix": "@description",
+        "body": [
+            "@description ${1:some description}"
+        ],
+        "description": "The @description tag allows you to provide a general description of the symbol you are documenting. The description may include HTML markup. It may also include Markdown formatting if the Markdown plugin is enabled. Synonysm of @desc."
+    },
+    "desc": {
+        "prefix": "@desc",
+        "body": [
+            "@desc ${1:some description}"
+        ],
+        "description": "The @description tag allows you to provide a general description of the symbol you are documenting. The description may include HTML markup. It may also include Markdown formatting if the Markdown plugin is enabled. Synonysm of @description."
+    },
+    "enum": {
+        "prefix": "@enum",
+        "body": [
+            "@enum ${1:type}"
+        ],
+        "description": "The @enum tag documents a collection of static properties whose values are all of the same type."
+    },
+    "event": {
+        "prefix": "@event",
+        "body": [
+            "@event ${1:class name}#[event]:${2:eventName}"
+        ],
+        "description": "Provide an example of how to use a documented item. The text that follows this tag will be displayed as highlighted code."
+    },
+    "example": {
+        "prefix": "@example",
+        "body": [
+            "@example ${1:some example}"
+        ],
+        "description": "The @event tag allows you to document an event that can be fired. A typical event is represented by an object with a defined set of properties."
+    },
+    "exports": {
+        "prefix": "@exports",
+        "body": [
+            "@exports ${1:moduleName}"
+        ],
+        "description": "Use the @exports tag when documenting JavaScript modules that export anything other than the \"exports\" object or the \"module.exports\" property."
+    },
+    "external": {
+        "prefix": "@external",
+        "body": [
+            "@external ${1:nameOfExternal}"
+        ],
+        "description": "The @external tag identifies a class, namespace, or module that is defined outside of the current package. Synonysm of @host."
+    },
+    "host": {
+        "prefix": "@host",
+        "body": [
+            "@host ${1:nameOfExternal}"
+        ],
+        "description": "The @external tag identifies a class, namespace, or module that is defined outside of the current package. Synonysm of @external."
+    },
+    "file": {
+        "prefix": "@file",
+        "body": [
+            "@file ${1:some description}"
+        ],
+        "description": "The @file tag provides a description for a file. Use the tag in a JSDoc comment at the beginning of the file. Synonysm of @fileoverview and @overview."
+    },
+    "fileoverview": {
+        "prefix": "@fileoverview",
+        "body": [
+            "@fileoverview ${1:some description}"
+        ],
+        "description": "The @file tag provides a description for a file. Use the tag in a JSDoc comment at the beginning of the file. Synonysm of @file and @overview."
+    },
+    "overview": {
+        "prefix": "@overview",
+        "body": [
+            "@overview ${1:some description}"
+        ],
+        "description": "The @file tag provides a description for a file. Use the tag in a JSDoc comment at the beginning of the file. Synonysm of @file and @fileoverview"
+    },
+    "fires": {
+        "prefix": "@fires",
+        "body": [
+            "@fires ${1:className}#[event:]${1:eventName}"
+        ],
+        "description": "Describe the events this method may fire. Synonysm of @emits."
+    },
+    "emits": {
+        "prefix": "@emits",
+        "body": [
+            "@emits ${1:className}#[event:]${1:eventName}"
+        ],
+        "description": "Describe the events this method may fire. Synonysm of @fires."
+    },
+    "function": {
+        "prefix": "@function",
+        "body": [
+            "@function"
+        ],
+        "description": "This marks an object as being a function, even though it may not appear to be one to the parser. Synonysm of @func and @method."
+    },
+    "func": {
+        "prefix": "@func",
+        "body": [
+            "@func"
+        ],
+        "description": "This marks an object as being a function, even though it may not appear to be one to the parser. Synonysm of @function and @method."
+    },
+    "method": {
+        "prefix": "@method",
+        "body": [
+            "@method"
+        ],
+        "description": "This marks an object as being a function, even though it may not appear to be one to the parser. Synonysm of @function and @func."
+    },
+    "generator": {
+        "prefix": "@generator",
+        "body": [
+            "@generator"
+        ],
+        "description": "Indicate that a function is a generator function."
+    },
+    "global": {
+        "prefix": "@global",
+        "body": [
+            "@global"
+        ],
+        "description": "Document a global object."
+    },
+    "hideconstructor": {
+        "prefix": "@hideconstructor",
+        "body": [
+            "@hideconstructor"
+        ],
+        "description": "Indicate that the constructor should not be displayed."
+    },
+    "ignore": {
+        "prefix": "@ignore",
+        "body": [
+            "@ignore"
+        ],
+        "description": "Omit a symbol from the documentation."
+    },
+    "implements": {
+        "prefix": "@implements",
+        "body": [
+            "@implements"
+        ],
+        "description": "This symbol implements an interface."
+    },
+    "inheritdoc": {
+        "prefix": "@inheritdoc",
+        "body": [
+            "@inheritdoc"
+        ],
+        "description": "Indicate that a symbol should inherit its parent's documentation."
+    },
+    "inner": {
+        "prefix": "@inner",
+        "body": [
+            "@inner"
+        ],
+        "description": "Using the @inner tag will mark a symbol as an inner member of its parent symbol. This means it can be referred to by \"Parent~Child\"."
+    },
+    "instance": {
+        "prefix": "@instance",
+        "body": [
+            "@instance"
+        ],
+        "description": "Using the @instance tag will mark a symbol as an instance member of its parent symbol. This means it can be referred to by \"Parent#Child\"."
+    },
+    "interface": {
+        "prefix": "@interface",
+        "body": [
+            "@interface"
+        ],
+        "description": "This symbol is an interface that others can implement."
+    },
+    "kind": {
+        "prefix": "@kind",
+        "body": [
+            "@kind ${1:kindName}"
+        ],
+        "description": "What kind of symbol is this. Possible values are: class, constant, event, external, file, function, member, mixin, module, namespace, typedef."
+    },
+    "lends": {
+        "prefix": "@lends",
+        "body": [
+            "@lends ${1:namePath}"
+        ],
+        "description": "The @lends tag allows you to document all the members of an object literal as if they were members of a symbol with the given name. You might want to do this if you are passing an object literal into a function that creates a named class from its members."
+    },
+    "license": {
+        "prefix": "@license",
+        "body": [
+            "@license ${1:identifier}"
+        ],
+        "description": "Identify the license that applies to this code."
+    },
+    "listens": {
+        "prefix": "@listens",
+        "body": [
+            "@listens ${1:eventName}"
+        ],
+        "description": "List the events that a symbol listens for."
+    },
+    "member": {
+        "prefix": "@member",
+        "body": [
+            "@member ${{1:type}}"
+        ],
+        "description": "Document a member. Synonysm or @var."
+    },
+    "var": {
+        "prefix": "@var",
+        "body": [
+            "@var ${{1:type}}"
+        ],
+        "description": "Document a member. Synonysm or @member."
+    },
+    "memberof": {
+        "prefix": "@memberof",
+        "body": [
+            "@memberof ${1:parentNamePath}"
+        ],
+        "description": "This symbol belongs to a parent symbol."
+    },
+    "mixes": {
+        "prefix": "@mixes",
+        "body": [
+            "@mixes ${1:OtherObjectPath}"
+        ],
+        "description": "This object mixes in all the members from another object."
+    },
+    "mixin": {
+        "prefix": "@mixin",
+        "body": [
+            "@mixin ${1:MixinName}"
+        ],
+        "description": "Document a mixin object."
+    },
+    "module": {
+        "prefix": "@module",
+        "body": [
+            "@module ${2:myModule}"
+        ],
+        "description": "Document a JavaScript module."
+    },
+    "name": {
+        "prefix": "@name",
+        "body": [
+            "@name ${1:namePath}"
+        ],
+        "description": "The @name tag forces JSDoc to associate the remainder of the JSDoc comment with the given name, ignoring all surrounding code. This tag is best used in \"virtual comments\" for symbols that are not readily visible in the code, such as methods that are generated at runtime."
+    },
+    "namespace": {
+        "prefix": "@namespace",
+        "body": [
+            "@namespace ${1:someName}"
+        ],
+        "description": "The @namespace tag indicates that an object creates a namespace for its members. You can also write a virtual JSDoc comment that defines a namespace used by your code."
     },
     "override": {
-        "prefix": "@over",
-        "body": ["@override"],
-        "description": "@override"
+        "prefix": "@override",
+        "body": [
+            "@override"
+        ],
+        "description": "The @override tag indicates that a symbol overrides a symbol with the same name in a parent class."
+    },
+    "package": {
+        "prefix": "@package",
+        "body": [
+            "@package"
+        ],
+        "description": "The @package tag marks a symbol as package-private. Typically, this tag indicates that a symbol is available only to code in the same directory as the source file for this symbol."
+    },
+    "param": {
+        "prefix": "@param",
+        "body": [
+            "@param ${{1:type}} ${2:paranName} - ${3:paramDescription}"
+        ],
+        "description": "Provides the name, type, and description of a function parameter. Synonysm of @arg and @argument."
+    },
+    "arg": {
+        "prefix": "@arg",
+        "body": [
+            "@arg ${{1:type}} ${2:paranName} - ${3:paramDescription}"
+        ],
+        "description": "Provides the name, type, and description of a function parameter. Synonysm of @param and @argument."
+    },
+    "argument": {
+        "prefix": "@argument",
+        "body": [
+            "@argument ${{1:type}} ${2:paranName} - ${3:paramDescription}"
+        ],
+        "description": "Provides the name, type, and description of a function parameter. Synonysm of @param and @arg."
+    },
+    "private": {
+        "prefix": "@private",
+        "body": [
+            "@private"
+        ],
+        "description": "Indicate this symbol is meant to be private."
+    },
+    "property": {
+        "prefix": "@property",
+        "body": [
+            "@property ${{1:type}} ${2:propertyName.something} - ${3:propertyDescription}"
+        ],
+        "description": "The @property tag is a way to easily document a list of static properties of a class, namespace or other object."
     },
     "protected": {
-        "prefix": "@pro",
-        "body": ["@protected"],
-        "description": "@protected"
+        "prefix": "@protected",
+        "body": [
+            "@protected"
+        ],
+        "description": "The @protected tag marks a symbol as protected. Typically, this tag indicates that a symbol is only available, or should only be used, within the current module."
+    },
+    "public": {
+        "prefix": "@publilc",
+        "body": [
+            "@public"
+        ],
+        "description": "Indicated this symbol is meant to be public."
+    },
+    "readonly": {
+        "prefix": "@readonly",
+        "body": [
+            "@readonly"
+        ],
+        "description": "Indicates this symbol is meant to be read-only."
+    },
+    "requires": {
+        "prefix": "@requires",
+        "body": [
+            "@requires ${1:moduleName}"
+        ],
+        "description": "Indicates a required module."
+    },
+    "returns": {
+        "prefix": "@returns",
+        "body": [
+            "@returns ${1:type} ${2:description}"
+        ],
+        "description": "Documents the value a function returns. Synonysm of @return."
+    },
+    "return": {
+        "prefix": "@return",
+        "body": [
+            "@return ${1:type} ${2:description}"
+        ],
+        "description": "Documents the value a function returns. Synonysm of @returns."
+    },
+    "see": {
+        "prefix": "@see",
+        "body": [
+            "@see ${1:text}"
+        ],
+        "description": "Refer to some other documentation for more information. It accepts text or {@link foobar}."
+    },
+    "since": {
+        "prefix": "@since",
+        "body": [
+            "@since ${1:version}"
+        ],
+        "description": "Version in which this symbol was added."
+    },
+    "static": {
+        "prefix": "@static",
+        "body": [
+            "@static"
+        ],
+        "description": "Indicates this is an static member."
+    },
+    "summary": {
+        "prefix": "@summary",
+        "body": [
+            "@summary ${1:summary goes here}"
+        ],
+        "description": "A shorter version of the full description."
+    },
+    "this": {
+        "prefix": "@this",
+        "body": [
+            "@this ${1:namePath}"
+        ],
+        "description": "The @this tag indicates what the this keyword refers to when used within another symbol."
+    },
+    "throws": {
+        "prefix": "@throws",
+        "body": [
+            "@throws ${1:errorName} ${2:description}"
+        ],
+        "description": "Describe what errors can be thrown. Synonysm of @exception."
+    },
+    "exception": {
+        "prefix": "@exception",
+        "body": [
+            "@exception ${1:errorName} ${2:description}"
+        ],
+        "description": "Describe what errors can be thrown. Synonysm of @throws."
+    },
+    "todo": {
+        "prefix": "@todo",
+        "body": [
+            "@todo ${1:text describing thing to do}"
+        ],
+        "description": "Documents a task to be completed."
+    },
+    "tutorial": {
+        "prefix": "@tutorial",
+        "body": [
+            "@tutorial"
+        ],
+        "description": "Link to a tutorial file."
+    },
+    "type": {
+        "prefix": "@type",
+        "body": [
+            "@type ${1:typeName}"
+        ],
+        "description": "Documents the type of the object."
+    },
+    "typedef": {
+        "prefix": "@typedef",
+        "body": [
+            "@typedef ${1:type} ${2:namePath}"
+        ],
+        "description": "Documents a custom type definition."
+    },
+    "variation": {
+        "prefix": "@variation",
+        "body": [
+            "@variation ${1:variationNumber}"
+        ],
+        "description": "Distinguish different objects with the same name."
+    },
+    "version": {
+        "prefix": "@version",
+        "body": [
+            "@version ${1:versionTag}"
+        ],
+        "description": "Documents the version number of an item."
+    },
+    "yields": {
+        "prefix": "@yields",
+        "body": [
+            "@yields ${{1:type}} ${2:description}"
+        ],
+        "description": "Document the value yielded by a generator function."
+    },
+    "link": {
+        "prefix": "@link",
+        "body": [
+            "@link ${1:namePathOrUrl}"
+        ],
+        "description": "Link to another item in the documentation. Synonysm of @linkcode and @linkplain."
+    },
+    "linkcode": {
+        "prefix": "@linkcode",
+        "body": [
+            "@linkcode ${1:namePathOrUrl}"
+        ],
+        "description": "Link to another item in the documentation. Synonysm of @link and @linkplain."
+    },
+    "linkplain": {
+        "prefix": "@linkplain",
+        "body": [
+            "@linkplain ${1:namePathOrUrl}"
+        ],
+        "description": "Link to another item in the documentation. Synonysm of @link and @linkcode."
     }
 }


### PR DESCRIPTION
This commit implements the [full specification of C# about code comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments#d3-recommended-tags).

This includes:
* The 18 official documentation tags of the language, all of them with auto completion and its official descriptions.
* Aditionally, writing /// creates a block of comments with description, parameter, return, and example. This is a common behavior in C# IDEs.

I'm adding them to the bottom of the file, so it doesn't spook future new contributors.