### PR TITLE
fix(ci): checkout (almost)  always fails

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Format JSON
         uses: creyD/prettier_action@v4.3


### PR DESCRIPTION
According to checkoutv3 docs: https://github.com/marketplace/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit