### PR TITLE
Add stops to ruby snippets

### DIFF
--- a/snippets/erb.json
+++ b/snippets/erb.json
@@ -48,7 +48,7 @@
     },
     "each": {
         "prefix": "each",
-        "body": ["<% ${1:items}.each do |${2:item}| %>", "  $2", "<% end %>"],
+        "body": ["<% ${1:items}.each do |${2:item}| %>", "  $3", "<% end %>"],
         "description": "each do"
     },
     "render": {

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -216,14 +216,6 @@
         "prefix": "->a",
         "body": "->(${1:args}) { $0 }"
     },
-    "Insert do block": {
-        "prefix": "do",
-        "body": ["do", "\t$0", "end"]
-    },
-    "Insert do block with variables": {
-        "prefix": "dov",
-        "body": ["do |${1:v}|", "\t$0", "end"]
-    },
     "Insert key: value": {
         "prefix": ":",
         "body": "${1:key}: ${2:value}"

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -144,6 +144,10 @@
         "prefix": ["{p", "{P"],
         "body": "{ ${1:|${2:variable}| }$0 "
     },
+    "Insert inline block with variable": {
+        "prefix": "b",
+        "body": "{ |${1:variable}| $2 }"
+    },
     "Insert encoding comment": {
         "prefix": "enc",
         "body": "# encoding: utf-8$0"
@@ -219,10 +223,6 @@
     "Insert key: value": {
         "prefix": ":",
         "body": "${1:key}: ${2:value}"
-    },
-    "Insert inline block": {
-        "prefix": "b",
-        "body": "{ |${1:var}| $0 }"
     },
     "Insert byebug call": {
         "prefix": "bye",

--- a/snippets/ruby.json
+++ b/snippets/ruby.json
@@ -1,31 +1,31 @@
 {
     "Exception block": {
         "prefix": "begin",
-        "body": ["begin", "\t$1", "rescue => exception", "\t", "end"]
+        "body": ["begin", "\t$1", "rescue ${2:StandardError} => ${3:exception}", "\t$0", "end"]
     },
     "Exception block with ensure": {
         "prefix": "begin ensure",
         "body": [
             "begin",
             "\t$1",
-            "rescue => exception",
-            "\t",
+            "rescue ${2:StandardError} => ${3:exception}",
+            "\t$4",
             "ensure",
-            "\t",
+            "\t$0",
             "end"
         ]
     },
     "Exception block with else and ensure": {
-        "prefix": "begin",
+        "prefix": "begin else",
         "body": [
             "begin",
             "\t$1",
-            "rescue => exception",
-            "\t",
+            "rescue ${2:StandardError} => ${3:exception}",
+            "\t$4",
             "else",
-            "\t",
+            "\t$5",
             "ensure",
-            "\t",
+            "\t$0",
             "end"
         ]
     },
@@ -33,7 +33,7 @@
         "prefix": "class init",
         "body": [
             "class ${1:ClassName}",
-            "\tdef initialize",
+            "\tdef initialize(${2:args})",
             "\t\t$0",
             "\tend",
             "end"
@@ -53,15 +53,15 @@
     },
     "if else": {
         "prefix": "ife",
-        "body": ["if ${1:test}", "\t$0", "else", "\t", "end"]
+        "body": ["if ${1:test}", "\t$2", "else", "\t$0", "end"]
     },
     "if elsif": {
         "prefix": "ifei",
-        "body": ["if ${1:test}", "\t$0", "elsif ", "\t", "end"]
+        "body": ["if ${1:test}", "\t$2", "elsif ${3:test}", "\t$0", "end"]
     },
     "if elsif else": {
         "prefix": "ifee",
-        "body": ["if ${1:test}", "\t$0", "elsif ", "\t", "else", "\t", "end"]
+        "body": ["if ${1:test}", "\t$2", "elsif ${3:test}", "\t$4", "else", "\t$0", "end"]
     },
     "case": {
         "prefix": "case",


### PR DESCRIPTION
Thanks for keeping this list of snippets. I'm proposing a few improvements to ruby snippets in this PR:

- Add more "stops" to blocks and `if`s snippets, so you can jump through them and fill the whole block.
- Fix an ERB snippet. It would previously end the snippet after adding the `item` and prefill just `item` on the body of the block. Now it will just have a jumpable body to be filled by the user.
- Remove duplicated inline block snippets.
- Update one of the inline block snippets to terminate after the bracket