### PR TITLE
feat(djangohtml): add snippet for blocktrans in a single line

### DIFF
--- a/snippets/frameworks/djangohtml.json
+++ b/snippets/frameworks/djangohtml.json
@@ -179,6 +179,11 @@
         "description": "blocktrans tag django template",
         "body": ["{% blocktrans %}", "  $1", "{% endblocktrans %}"]
     },
+    "blocktransinline": {
+        "prefix": "blocktransinline",
+        "description": "blocktrans tag django template (single line)",
+        "body": ["{% blocktrans %}$1{% endblocktrans %}"]
+    },
     "super": {
         "prefix": "super",
         "description": "Block super",


### PR DESCRIPTION
There are a few use cases in Django for using "blocktrans" tags in a single line (despite the "block" in the name).

Unfortunately, the provided snippet for the block inserts line breaks.

I created a copy of this snipped with a similar name for inserting single-line block tag pairs.