### PR TITLE
feat(shelldoc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
             },
             {
                 "language": ["csharp", "cs"],
-                "path": "./snippets/csharp.json"
+                "path": "./snippets/csharp/csharp.json"
+            },
+            {
+                "language": "csharpdoc",
+                "path": "./snippets/csharp/csharpdoc.json"
             },
             {
                 "language": ["gitcommit", "NeogitCommitMessage"],
@@ -106,7 +110,11 @@
             },
             {
                 "language": "rust",
-                "path": "./snippets/rust.json"
+                "path": "./snippets/rust/rust.json"
+            },
+            {
+                "language": "rustdoc",
+                "path": "./snippets/rust/rustdoc.json"
             },
             {
                 "language": "rust",
@@ -150,7 +158,11 @@
             },
             {
                 "language": ["shellscript", "shell", "sh", "zsh"],
-                "path": "./snippets/shell.json"
+                "path": "./snippets/shell/shell.json"
+            },
+            {
+                "language": "shelldoc",
+                "path": "./snippets/shell/shelldoc.json"
             },
             {
                 "language": ["markdown", "rmd"],
@@ -279,6 +291,10 @@
             {
                 "language": "python",
                 "path": "./snippets/python/unittest.json"
+            },
+            {
+                "language": "python-docstring",
+                "path": "./snippets/python/python-docstring.json"
             },
             {
                 "language": "django",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,7 @@
             },
             {
                 "language": ["csharp", "cs"],
-                "path": "./snippets/csharp/csharp.json"
-            },
-            {
-                "language": "csharpdoc",
-                "path": "./snippets/csharp/csharpdoc.json"
+                "path": "./snippets/csharp.json"
             },
             {
                 "language": ["gitcommit", "NeogitCommitMessage"],
@@ -110,11 +106,7 @@
             },
             {
                 "language": "rust",
-                "path": "./snippets/rust/rust.json"
-            },
-            {
-                "language": "rustdoc",
-                "path": "./snippets/rust/rustdoc.json"
+                "path": "./snippets/rust.json"
             },
             {
                 "language": "rust",
@@ -291,10 +283,6 @@
             {
                 "language": "python",
                 "path": "./snippets/python/unittest.json"
-            },
-            {
-                "language": "python-docstring",
-                "path": "./snippets/python/python-docstring.json"
             },
             {
                 "language": "django",

--- a/snippets/shell/shell.json
+++ b/snippets/shell/shell.json
@@ -1,17 +1,4 @@
 {
-    "bash": {
-        "prefix": ["bash", "#!", "shebang"],
-        "body": "${1|#!/bin/bash,#!/usr/bin/env bash,#!/bin/sh,#!/usr/bin/env sh|}\n",
-        "description": [
-            "Option 1:\n",
-            "#!/bin/bash\n",
-            "Description: Shebang Bash executor.\n",
-            "Option 2:\n",
-            "#!/usr/bin/env bash\n",
-            "Description: Shell searchs for the first match of bash in the $PATH environment variable.\n",
-            "It can be useful if you aren't aware of the absolute path or don't want to search for it.\n"
-        ]
-    },
     "echo": {
         "prefix": "echo",
         "body": "echo \"${0:message}\"",

--- a/snippets/shell/shelldoc.json
+++ b/snippets/shell/shelldoc.json
@@ -22,7 +22,7 @@
             "# Outputs:",
             "#   ${5:Output to STDOUT or STDERR.}",
             "# Returns:",
-            "#   ${2: Description of the returned item.}",
+            "#   ${2: Description of the returned value.}",
             "#######################################"
         ],
         "description": "A shell comment block for functions, including description, globals, arguments, outputs, and returns.\n\nYou can delete 'Globals'/'Arguments'/'Outputs' in functions with no input/output.\n\nIt doesn't includes, but accepts the optional keywords:\n  'See'\n  'Raises'"

--- a/snippets/shell/shelldoc.json
+++ b/snippets/shell/shelldoc.json
@@ -25,7 +25,7 @@
             "#   ${2: Description of the returned value.}",
             "#######################################"
         ],
-        "description": "A shell comment block for functions, including description, globals, arguments, outputs, and returns.\n\nYou can delete 'Globals'/'Arguments'/'Outputs' in functions with no input/output.\n\nIt doesn't includes, but accepts the optional keywords:\n  'See'\n  'Raises'"
+        "description": "A shell comment block for functions, including description, globals, arguments, outputs, and returns. For functions without I/O, use the simple version of this snippet instead.\n\nYou can delete 'Globals'/'Arguments'/'Outputs' in functions with no input/output.\n\nIt doesn't includes, but accepts the optional keywords:\n  'See'\n  'Raises'"
     },
     "comment_simple": {
         "prefix": "##",

--- a/snippets/shell/shelldoc.json
+++ b/snippets/shell/shelldoc.json
@@ -1,0 +1,39 @@
+{
+    "shebang": {
+        "prefix": "#!/usr/bin/env",
+        "body": [
+            "#!/usr/bin/env ${1:sh}",
+            "#",
+            "# ${2:Description of the script.}$0"
+        ],
+        "description": [
+            "Shebang to specify what shell is going to run the script by default. It includes a description of the script. \n\nIt must be defined in the first line of the script.\n\nBy using #!/usr/bin/env we are making the shebang portable, meaning it is going to work correctly even if the interpreter is not located under /usr/bin"
+        ]
+    },
+    "comment": {
+        "prefix": "###",
+        "body": [
+            "#######################################",
+            "# ${1:Description of the function.}$0",
+            "# Globals:",
+            "#   ${3:MY_VAR}",
+            "# Arguments:",
+            "#   ${4:None}",
+            "# Outputs:",
+            "#   ${5:Output to STDOUT or STDERR.}",
+            "# Returns:",
+            "#   ${2: Description of the returned item.}",
+            "#######################################"
+        ],
+        "description": "A shell comment block for functions, including description, globals, arguments, outputs, and returns.\n\nYou can delete 'Globals'/'Arguments'/'Outputs' in functions with no input/output.\n\nIt doesn't includes, but accepts the optional keywords:\n  'See'\n  'Raises'"
+    },
+    "comment_simple": {
+        "prefix": "##",
+        "body": [
+            "#######################################",
+            "# ${1:Description of the function.}$0",
+            "#######################################"
+        ],
+        "description": "A simple shell comment block for functions, with a description. Useful when the user prefers to add the other documentation tags manually."
+    }
+}


### PR DESCRIPTION
This PR implements the [full specification of google styling guide for shell](https://google.github.io/styleguide/shellguide.html#s4-comments).

## This includes
* 1 shebang snippet `!/usr/bin/env` with auto completion.
* 2 shelldoc comments for shell functions, with auto completion.

![screenshot_2023-06-13_23-08-31_966966531](https://github.com/rafamadriz/friendly-snippets/assets/3357792/73429c6f-fa1b-4401-9b26-9607537d6e3b)


![screenshot_2023-06-13_23-10-04_133477824](https://github.com/rafamadriz/friendly-snippets/assets/3357792/177ec9c9-9b10-4dd4-9985-79a8965a1d5d)
