### PR TITLE
fix(luadoc) comments format

### DIFF
--- a/snippets/lua/luadoc.json
+++ b/snippets/lua/luadoc.json
@@ -1,5 +1,5 @@
 {
-  "---": {
+  "comment": {
     "prefix": "---",
     "body": [
       "--- ${1:A one-line summay.}",
@@ -8,7 +8,15 @@
       "-- @return ${3:type} ${4: Description of the returned object.}",
       "-- @usage ${8:Example about how to use it.}"
     ],
-    "description": "A lua comment with description, parameters, return, and example."
+    "description": "A lua comment with short summary, description, parameters, return, and example."
+  },
+  "comment_simple": {
+    "prefix": "--",
+    "body": [
+      "--- ${1:A one-line summay.}",
+      "-- ${2:Description.}$0"
+    ],
+    "description": "A simple lua comment with short summary and description. Useful when you prefer to add the tags manually on functions."
   },
   "@author": {
     "prefix": "@author",

--- a/snippets/lua/luadoc.json
+++ b/snippets/lua/luadoc.json
@@ -6,7 +6,7 @@
       "-- ${2:Description.}$0",
       "-- @param ${5:name} ${6:type} ${7:Parameter description.}",
       "-- @return ${3:type} ${4: Description of the returned object.}",
-      "-- @usage ${8:Example about how to use it.}",
+      "-- @usage ${8:Example about how to use it.}"
     ],
     "description": "A lua comment with description, parameters, return, and example."
   },

--- a/snippets/lua/luadoc.json
+++ b/snippets/lua/luadoc.json
@@ -2,10 +2,11 @@
   "---": {
     "prefix": "---",
     "body": [
-      "--- ${1:Description.}",
-      "---@param ${4:name} ${5:type} ${6:Parameter description.}",
-      "---@return ${2:type} ${3: Description of the returned object.}",
-      "-- @usage ${7:Example about how to use it.}$0"
+      "--- ${1:A one-line summay.}",
+      "-- ${2:Description.}$0",
+      "-- @param ${5:name} ${6:type} ${7:Parameter description.}",
+      "-- @return ${3:type} ${4: Description of the returned object.}",
+      "-- @usage ${8:Example about how to use it.}",
     ],
     "description": "A lua comment with description, parameters, return, and example."
   },


### PR DESCRIPTION
Luadoc actually tell us to use this format for comments. This makes the first line be the briefing.