### PR TITLE
feat(HTML): Add shortcut for class and id attirbutes

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -693,5 +693,77 @@
         ],
         "description": "HTML - Defines a video",
         "scope": "text.html"
+    },
+"div.": {
+        "prefix": "div.",
+        "body": ["<div class=\"$1\">", "\t$2", "</div>"],
+        "description": "HTML - Defines a section in a document",
+        "scope": "text.html"
+    },
+"div#": {
+        "prefix": "div#",
+        "body": ["<div id=\"$1\">", "\t$2", "</div>"],
+        "description": "HTML - Defines a section in a document",
+        "scope": "text.html"
+    },
+"div.#": {
+        "prefix": "div.#",
+        "body": ["<div class=\"$1\" id=\"$2\">", "\t$3", "</div>"],
+        "description": "HTML - Defines a section in a document",
+        "scope": "text.html"
+    },
+"p.": {
+        "prefix": "p.",
+        "body": ["<p class=\"$1\">$2</p>"],
+        "description": "HTML - Defines a paragraph",
+        "scope": "text.html"
+    },
+"p#": {
+        "prefix": "p#",
+        "body": ["<p id=\"$1\">$2</p>"],
+        "description": "HTML - Defines a paragraph",
+        "scope": "text.html"
+    },
+"p.#": {
+        "prefix": "p.#",
+        "body": ["<p class=\"$1\" id=\"$2\">$3</p>"],
+        "description": "HTML - Defines a paragraph",
+        "scope": "text.html"
+    },
+"ul.": {
+        "prefix": "ul.",
+        "body": ["<ul class=\"$1\">", "\t$2", "</ul>"],
+        "description": "HTML - Defines an unordered list",
+        "scope": "text.html"
+    },
+"ul#": {
+        "prefix": "ul#",
+        "body": ["<ul id=\"$1\">", "\t$2", "</ul>"],
+        "description": "HTML - Defines an unordered list",
+        "scope": "text.html"
+    },
+"ul.#": {
+        "prefix": "ul.#",
+        "body": ["<ul class=\"$1\" id=\"$2\">", "\t$3", "</ul>"],
+        "description": "HTML - Defines an unordered list",
+        "scope": "text.html"
+    },
+"ol.": {
+        "prefix": "ol.",
+        "body": ["<ol class=\"$1\">", "\t$2", "</ol>"],
+        "description": "HTML - Defines an ordered list",
+        "scope": "text.html"
+    },
+"ol#": {
+        "prefix": "ol#",
+        "body": ["<ol id=\"$1\">", "\t$2", "</ol>"],
+        "description": "HTML - Defines an ordered list",
+        "scope": "text.html"
+    },
+"ol.#": {
+        "prefix": "ol.#",
+        "body": ["<ol class=\"$1\" id=\"$2\">", "\t$3", "</ol>"],
+        "description": "HTML - Defines an ordered list",
+        "scope": "text.html"
     }
 }


### PR DESCRIPTION
Added shortcut to rapidly add class and id for common tags, such as `div`, `p` and lists