### PR TITLE
fix(doc) Typos for all languages

### DIFF
--- a/snippets/c/cdoc.json
+++ b/snippets/c/cdoc.json
@@ -17,7 +17,7 @@
         ],
         "description": "A C comment block for functions, including short summary, details, param, return, and example."
     },
-     "comment_simple": {
+    "comment_simple": {
         "prefix": "/*",
         "body": [
             "/**",

--- a/snippets/c/cdoc.json
+++ b/snippets/c/cdoc.json
@@ -3,7 +3,7 @@
         "prefix": "/**",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " *",
@@ -21,7 +21,7 @@
         "prefix": "/*",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " */"

--- a/snippets/cpp/cppdoc.json
+++ b/snippets/cpp/cppdoc.json
@@ -3,7 +3,7 @@
         "prefix": "/**",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " *",
@@ -21,7 +21,7 @@
         "prefix": "/*",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " */"
@@ -56,13 +56,13 @@
         "body": [
             "@throws ${1:ExceptionName} ${2:Description.}$0"
         ],
-        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonism of @exception."
+        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonym of @exception."
     },
     "@exception": {
         "prefix": "@exception",
         "body": [
             "@exception ${1:ExceptionName} ${2:Description.}$0"
         ],
-        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonism of @throws."
+        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonym of @throws."
     }
 }

--- a/snippets/java/javadoc.json
+++ b/snippets/java/javadoc.json
@@ -3,7 +3,7 @@
         "prefix": "/**",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " *",
@@ -22,7 +22,7 @@
         "prefix": "/*",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " */"
@@ -65,14 +65,14 @@
         "body": [
             "@throws ${1:IOException} ${2:Description.}$0"
         ],
-        "description": "Document an exception raised by the item. Synonism of @exception."
+        "description": "Document an exception raised by the item. Synonym of @exception."
     },
     "@exception": {
         "prefix": "@exception",
         "body": [
             "@exception ${1:IOException} ${2:Description.}$0"
         ],
-        "description": "Document an exception raised by the item. Synonism of @throws."
+        "description": "Document an exception raised by the item. Synonym of @throws."
     },
     "@since": {
         "prefix": "@since",

--- a/snippets/lua/luadoc.json
+++ b/snippets/lua/luadoc.json
@@ -2,7 +2,7 @@
   "comment": {
     "prefix": "---",
     "body": [
-      "--- ${1:A one-line summay.}",
+      "--- ${1:A one-line summary.}",
       "-- ${2:Description.}$0",
       "-- @param ${5:name} ${6:type} ${7:Parameter description.}",
       "-- @return ${3:type} ${4: Description of the returned object.}",
@@ -13,7 +13,7 @@
   "comment_simple": {
     "prefix": "--",
     "body": [
-      "--- ${1:A one-line summay.}",
+      "--- ${1:A one-line summary.}",
       "-- ${2:Description.}$0"
     ],
     "description": "A simple lua comment with short summary and description. Useful when you prefer to add the tags manually on functions."

--- a/snippets/php/phpdoc.json
+++ b/snippets/php/phpdoc.json
@@ -3,7 +3,7 @@
         "prefix": "/**",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " *",
@@ -21,7 +21,7 @@
         "prefix": "/*",
         "body": [
             "/**",
-            " * ${1:A one-line summay.}",
+            " * ${1:A one-line summary.}",
             " *",
             " * ${2:Description.}$0",
             " */"
@@ -56,14 +56,14 @@
         "body": [
             "@throws ${1:ExceptionName} ${2:Description.}$0"
         ],
-        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonism of @exception."
+        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonym of @exception."
     },
     "@exception": {
         "prefix": "@exception",
         "body": [
             "@exception ${1:ExceptionName} ${2:Description.}$0"
         ],
-        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonism of @throws."
+        "description": "Indicates the exceptions that can be thrown by a function. This tag is a synonym of @throws."
     }
 }
 

--- a/snippets/python/pydoc.json
+++ b/snippets/python/pydoc.json
@@ -3,7 +3,7 @@
         "prefix": "\"\"\"",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -18,13 +18,13 @@
             "    ${7:use_it_this_way(arg1, arg2)}",
             "\"\"\""
         ],
-        "description": "A Python docstring for functions and methods, including short summary, details, args, returns, and examples. This docstring is an synonism of \"\"\"function."
+        "description": "A Python docstring for functions and methods, including short summary, details, args, returns, and examples. This docstring is an synonym of \"\"\"function."
     },
     "comment simple": {
         "prefix": "\"\"",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "\"\"\""
@@ -35,7 +35,7 @@
         "prefix": "\"\"\"module",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -61,7 +61,7 @@
         "prefix": "\"\"\"function",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -82,7 +82,7 @@
         "prefix": "\"\"\"function_typed",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -103,7 +103,7 @@
         "prefix": "\"\"\"generator",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -124,7 +124,7 @@
         "prefix": "\"\"\"class",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",
@@ -138,7 +138,7 @@
         "prefix": "\"\"\"exception",
         "body": [
             "\"\"\"",
-            "${1:A one-line summay.}",
+            "${1:A one-line summary.}",
             "",
             "${2:Detailed description.}$0",
             "",


### PR DESCRIPTION
This PR is the same as  #344 but we apply it to all languages (not only cpp).

It also includes the typo fix originally included in #341. In other words, we are applying all doc related typo fixes in this single PR, which should make it easier to review.

Thank you so much @surmish and @REmerald for reporting 🔥