### PR TITLE
fix(gdscript): update match snippet

### DIFF
--- a/snippets/gdscript.json
+++ b/snippets/gdscript.json
@@ -88,7 +88,7 @@
     
     "match": {
         "prefix": "match",
-        "body": ["match ${1:expression}: {\n${2:pattern(s)}:\n\t$0\n}"]
+        "body": ["match ${1:expression}:\n\t${2:pattern}:\n\t\t${3}\n\t_:\n\t\t${0:default}"]
     },
 
     "signal declaration": {


### PR DESCRIPTION
The match statement was incorrect in multiple ways. This updates it so that it actually reflects the match statement as specified in godot's documentation: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#match