### PR TITLE
(fix latex): label-caption space chktex warning24

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -192,12 +192,12 @@
     },
     "figure": {
         "prefix": "BFI",
-        "body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{figure}",
+        "body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}\\label{${3:<label>}}\n\\end{figure}",
         "description": "figure"
     },
     "table": {
         "prefix": "BTA",
-        "body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\n\t\\label{${3:<label>}}\n\\end{table}",
+        "body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\\label{${3:<label>}}\n\\end{table}",
         "description": "table"
     },
     "tikzpicture": {

--- a/snippets/latex/latex-snippets.json
+++ b/snippets/latex/latex-snippets.json
@@ -108,8 +108,7 @@
             "\t\\floatname{algorithm}{${1:Algorithm}}",
             "\t\\algrenewcommand\\algorithmicrequire{\\textbf{${2:Input: }}}",
             "\t\\algrenewcommand\\algorithmicensure{\\textbf{${3:Output: }}}",
-            "\t\\caption{$4}",
-            "\t\\label{alg:$5}",
+            "\t\\caption{$4}\\label{alg:$5}",
             "\t\\begin{algorithmic}[1]",
             "\t\t\\Require \\$input\\$",
             "\t\t\\Ensure \\$output\\$",
@@ -290,8 +289,7 @@
             "\t\\begin{center}",
             "\t\t\\includegraphics[width=0.95\\textwidth]{figures/$1}",
             "\t\\end{center}",
-            "\t\\caption{$3}",
-            "\t\\label{fig:$4}",
+            "\t\\caption{$3}\\label{fig:$4}",
             "\\end{figure}",
             "$0"
         ],
@@ -302,8 +300,7 @@
         "body": [
             "\\begin{figure}",
             "\t\\includegraphics[width=0.45\\textwidth]{figures/$1}",
-            "\t\\caption{$2}",
-            "\t\\label{fig:$3}",
+            "\t\\caption{$2}\\label{fig:$3}",
             "\\end{figure}",
             "$0"
         ],
@@ -314,8 +311,7 @@
         "body": [
             "\\begin{figure*}",
             "\t\\includegraphics[width=0.45\\textwidth]{figures/$1}",
-            "\t\\caption{$2}",
-            "\t\\label{fig:$3}",
+            "\t\\caption{$2}\\label{fig:$3}",
             "\\end{figure*}",
             "$0"
         ],
@@ -325,8 +321,7 @@
         "prefix": "table",
         "body": [
             "\\begin{table}",
-            "\t\\caption{$1}",
-            "\t\\label{tab:$2}",
+            "\t\\caption{$1}\\label{tab:$2}",
             "\t\\begin{center}",
             "\t\t\\begin{tabular}[c]{l|l}",
             "\t\t\t\\hline",
@@ -348,8 +343,7 @@
         "prefix": "table:acm",
         "body": [
             "\\begin{table}",
-            "\t\\caption{$1}",
-            "\t\\label{tab:$2}",
+            "\t\\caption{$1}\\label{tab:$2}",
             "\t\\begin{tabular}{${3:ccl}}",
             "\t\t\\toprule",
             "\t\t$4",
@@ -367,8 +361,7 @@
         "prefix": "table:acm:*",
         "body": [
             "\\begin{table*}",
-            "\t\\caption{$1}",
-            "\t\\label{tab:$2}",
+            "\t\\caption{$1}\\label{tab:$2}",
             "\t\\begin{tabular}{${3:ccl}}",
             "\t\t\\toprule",
             "\t\t$4",


### PR DESCRIPTION
Description:
I noticed some snippets that included label-caption couples made chktex give warnings regarding the warning 24 [Delete this space to maintain correct page references.]. Therefore, i made the necessary changes to improve the usability of the snippets.  

I think this is major issue, because of the heavy use of snippets in the creating of LaTeX documents.

Thank you for your effort and time! :)