### PR TITLE
fix useState snippet to automatically capitalize setter function name

### DIFF
--- a/snippets/javascript/react-ts.json
+++ b/snippets/javascript/react-ts.json
@@ -284,8 +284,8 @@
     },
     "useState": {
         "prefix": "us",
-        "body": "const [${1:val}, set${2:setterName}] = useState(${3:defVal})",
-        "description": "use state hook"
+        "body": "const [${1:state}, set${1/(.*)/${1:/capitalize}/}] = useState(${2:initValue})$0",
+        "description": "React useState() hook"
     },
     "useEffect": {
         "prefix": "ue",

--- a/snippets/javascript/react.json
+++ b/snippets/javascript/react.json
@@ -298,8 +298,8 @@
     },
     "useState": {
         "prefix": "us",
-        "body": "const [${1:setterName}, set${1:setterName}] = useState(${2:defVal})$0",
-        "description": "use state hook"
+        "body": "const [${1:state}, set${1/(.*)/${1:/capitalize}/}] = useState(${2:initValue})$0",
+        "description": "React useState() hook"
     },
     "useEffect": {
         "prefix": "ue",


### PR DESCRIPTION
Recognized that the "us" snippet wasn't automatically capitalizing the setter function name. Addressed this by implementing a fix that now ensures the setter function is appropriately capitalized.