### PR TITLE
Latex: Removed '~' from Cite body

### DIFF
--- a/snippets/latex/latex-snippets.json
+++ b/snippets/latex/latex-snippets.json
@@ -392,7 +392,7 @@
     },
     "Cite": {
         "prefix": "cite",
-        "body": ["~\\cite{$1}$0"],
+        "body": ["\\cite{$1}$0"],
         "description": "Add a cite"
     },
     "EmptyPage": {


### PR DESCRIPTION
Calling and expanding "cite" would result in "~\cite{}" in stead of "\cite{}"
