### PR TITLE
add blade snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,602 +1,546 @@
 {
-  "name": "friendly-snippets",
-  "engines": {
-    "vscode": "^1.11.0"
-  },
-  "contributes": {
-    "snippets": [
-      {
-        "language": [
-          "plaintext",
-          "markdown",
-          "tex",
-          "html",
-          "global",
-          "all"
-        ],
-        "path": "./snippets/global.json"
-      },
-      {
-        "language": [
-          "license"
-        ],
-        "path": "./snippets/license.json"
-      },
-      {
-        "language": "c",
-        "path": "./snippets/c/c.json"
-      },
-      {
-        "language": "cdoc",
-        "path": "./snippets/c/cdoc.json"
-      },
-      {
-        "language": "cpp",
-        "path": "./snippets/cpp/cpp.json"
-      },
-      {
-        "language": "cppdoc",
-        "path": "./snippets/cpp/cppdoc.json"
-      },
-      {
-        "language": [
-          "csharp",
-          "cs"
-        ],
-        "path": "./snippets/csharp/csharp.json"
-      },
-      {
-        "language": "csharpdoc",
-        "path": "./snippets/csharp/csharpdoc.json"
-      },
-      {
-        "language": [
-          "gitcommit",
-          "NeogitCommitMessage"
-        ],
-        "path": "./snippets/gitcommit.json"
-      },
-      {
-        "language": "ejs",
-        "path": "./snippets/frameworks/ejs.json"
-      },
-      {
-        "language": "eruby",
-        "path": "./snippets/erb.json"
-      },
-      {
-        "language": "erlang",
-        "path": "./snippets/erlang.json"
-      },
-      {
-        "language": "elixir",
-        "path": "./snippets/elixir.json"
-      },
-      {
-        "language": [
-          "eelixir",
-          "heex"
-        ],
-        "path": "./snippets/eelixir.json"
-      },
-      {
-        "language": "fortran",
-        "path": "./snippets/fortran.json"
-      },
-      {
-        "language": "glsl",
-        "path": "./snippets/glsl.json"
-      },
-      {
-        "language": "nix",
-        "path": "./snippets/nix.json"
-      },
-      {
-        "language": "liquid",
-        "path": "./snippets/liquid.json"
-      },
-      {
-        "language": "lua",
-        "path": "./snippets/lua/lua.json"
-      },
-      {
-        "language": "luadoc",
-        "path": "./snippets/lua/luadoc.json"
-      },
-      {
-        "language": "go",
-        "path": "./snippets/go.json"
-      },
-      {
-        "language": "fennel",
-        "path": "./snippets/fennel.json"
-      },
-      {
-        "language": "fsh",
-        "path": "./snippets/fsh.json"
-      },
-      {
-        "language": "php",
-        "path": "./snippets/php/php.json"
-      },
-      {
-        "language": "phpdoc",
-        "path": "./snippets/php/phpdoc.json"
-      },
-      {
-        "language": "quarto",
-        "path": "./snippets/quarto.json"
-      },
-      {
-        "language": "rescript",
-        "path": "./snippets/rescript.json"
-      },
-      {
-        "language": "ruby",
-        "path": "./snippets/ruby/ruby.json"
-      },
-      {
-        "language": "rdoc",
-        "path": "./snippets/ruby/rdoc.json"
-      },
-      {
-        "language": "rails",
-        "path": "./snippets/frameworks/rails.json"
-      },
-      {
-        "language": "rust",
-        "path": "./snippets/rust/rust.json"
-      },
-      {
-        "language": "rustdoc",
-        "path": "./snippets/rust/rustdoc.json"
-      },
-      {
-        "language": "rust",
-        "path": "./snippets/frameworks/relm4/workers.json"
-      },
-      {
-        "language": "rust",
-        "path": "./snippets/frameworks/relm4/factories.json"
-      },
-      {
-        "language": "rust",
-        "path": "./snippets/frameworks/relm4/templates.json"
-      },
-      {
-        "language": "rust",
-        "path": "./snippets/frameworks/relm4/components.json"
-      },
-      {
-        "language": "haskell",
-        "path": "./snippets/haskell.json"
-      },
-      {
-        "language": "scala",
-        "path": "./snippets/scala.json"
-      },
-      {
-        "language": "solidity",
-        "path": "./snippets/solidity.json"
-      },
-      {
-        "language": "swift",
-        "path": "./snippets/swift.json"
-      },
-      {
-        "language": "sql",
-        "path": "./snippets/sql.json"
-      },
-      {
-        "language": "systemverilog",
-        "path": "./snippets/systemverilog.json"
-      },
-      {
-        "language": [
-          "shellscript",
-          "shell",
-          "sh",
-          "zsh"
-        ],
-        "path": "./snippets/shell/shell.json"
-      },
-      {
-        "language": "shelldoc",
-        "path": "./snippets/shell/shelldoc.json"
-      },
-      {
-        "language": [
-          "markdown",
-          "rmd"
-        ],
-        "path": "./snippets/markdown.json"
-      },
-      {
-        "language": [
-          "plaintex",
-          "tex"
-        ],
-        "path": "./snippets/latex.json"
-      },
-      {
-        "language": "plantuml",
-        "path": "./snippets/plantuml.json"
-      },
-      {
-        "language": "java",
-        "path": "./snippets/java/java.json"
-      },
-      {
-        "language": "java-testing",
-        "path": "./snippets/java/java-tests.json"
-      },
-      {
-        "language": "javadoc",
-        "path": "./snippets/java/javadoc.json"
-      },
-      {
-        "language": "julia",
-        "path": "./snippets/julia.json"
-      },
-      {
-        "language": [
-          "html",
-          "jade",
-          "pug",
-          "eruby",
-          "javascriptreact",
-          "htmldjango",
-          "astro",
-          "blade"
-        ],
-        "path": "./snippets/html.json"
-      },
-      {
-        "language": [
-          "css",
-          "scss",
-          "sass",
-          "less",
-          "stylus"
-        ],
-        "path": "./snippets/css.json"
-      },
-      {
-        "language": [
-          "javascript",
-          "javascriptreact",
-          "vue",
-          "svelte"
-        ],
-        "path": "./snippets/javascript/javascript.json"
-      },
-      {
-        "language": "jsdoc",
-        "path": "./snippets/javascript/jsdoc.json"
-      },
-      {
-        "language": "tsdoc",
-        "path": "./snippets/javascript/tsdoc.json"
-      },
-      {
-        "language": [
-          "typescript",
-          "typescriptreact"
-        ],
-        "path": "./snippets/javascript/typescript.json"
-      },
-      {
-        "language": "javascriptreact",
-        "path": "./snippets/javascript/react.json"
-      },
-      {
-        "language": "javascriptreact",
-        "path": "./snippets/javascript/react-native.json"
-      },
-      {
-        "language": "javascriptreact",
-        "path": "./snippets/javascript/next.json"
-      },
-      {
-        "language": "typescriptreact",
-        "path": "./snippets/javascript/react-ts.json"
-      },
-      {
-        "language": "typescriptreact",
-        "path": "./snippets/javascript/next-ts.json"
-      },
-      {
-        "language": "typescriptreact",
-        "path": "./snippets/javascript/react-native-ts.json"
-      },
-      {
-        "language": [
-          "javascriptreact",
-          "typescriptreact"
-        ],
-        "path": "./snippets/javascript/react-es7.json"
-      },
-      {
-        "language": "svelte",
-        "path": "./snippets/svelte.json"
-      },
-      {
-        "language": "vue",
-        "path": "./snippets/frameworks/vue/html.json"
-      },
-      {
-        "language": "vue",
-        "path": "./snippets/frameworks/vue/nuxt_html.json"
-      },
-      {
-        "language": "vue",
-        "path": "./snippets/frameworks/vue/nuxt_js_ts.json"
-      },
-      {
-        "language": "vue",
-        "path": "./snippets/frameworks/vue/javascript.json"
-      },
-      {
-        "language": "vue",
-        "path": "./snippets/frameworks/vue/vue.json"
-      },
-      {
-        "language": "angular",
-        "path": "./snippets/frameworks/angular/html.json"
-      },
-      {
-        "language": "angular",
-        "path": "./snippets/frameworks/angular/typescript.json"
-      },
-      {
-        "language": "angular",
-        "path": "./snippets/frameworks/angular/jsonc.json"
-      },
-      {
-        "language": "python",
-        "path": "./snippets/python/base.json"
-      },
-      {
-        "language": "python",
-        "path": "./snippets/python/comprehension.json"
-      },
-      {
-        "language": "python",
-        "path": "./snippets/python/debug.json"
-      },
-      {
-        "language": "python",
-        "path": "./snippets/python/python.json"
-      },
-      {
-        "language": "python",
-        "path": "./snippets/python/unittest.json"
-      },
-      {
-        "language": "pydoc",
-        "path": "./snippets/python/pydoc.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/admin.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/forms.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/models.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/tags.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/urls.json"
-      },
-      {
-        "language": "django",
-        "path": "./snippets/frameworks/django/views.json"
-      },
-      {
-        "language": [
-          "djangohtml",
-          "htmldjango"
-        ],
-        "path": "./snippets/frameworks/djangohtml.json"
-      },
-      {
-        "language": "django-rest",
-        "path": "./snippets/frameworks/django/django_rest/serializers.json"
-      },
-      {
-        "language": "django-rest",
-        "path": "./snippets/frameworks/django/django_rest/views.json"
-      },
-      {
-        "language": "flutter",
-        "path": "./snippets/frameworks/flutter.json"
-      },
-      {
-        "language": "jekyll",
-        "path": "./snippets/frameworks/jekyll.json"
-      },
-      {
-        "language": "cobol",
-        "path": "./snippets/cobol/vscode_cobol.json"
-      },
-      {
-        "language": "cobol",
-        "path": "./snippets/cobol/vscode_cobol-compound.json"
-      },
-      {
-        "language": "cobol",
-        "path": "./snippets/cobol/vscode_cobol_dir.json"
-      },
-      {
-        "language": "cobol",
-        "path": "./snippets/cobol/vscode_cobol_jcl.json"
-      },
-      {
-        "language": "kotlin",
-        "path": "./snippets/kotlin/kotlin.json"
-      },
-      {
-        "language": "kdoc",
-        "path": "./snippets/kotlin/kdoc.json"
-      },
-      {
-        "language": [
-          "plaintex",
-          "tex"
-        ],
-        "path": "./snippets/latex/latex-snippets.json"
-      },
-      {
-        "language": [
-          "plaintex",
-          "tex"
-        ],
-        "path": "./snippets/latex/vscode-latex-snippets.json"
-      },
-      {
-        "language": [
-          "bibtex",
-          "bib"
-        ],
-        "path": "./snippets/latex/bibtex.json"
-      },
-      {
-        "language": "twig",
-        "path": "./snippets/frameworks/twig.json"
-      },
-      {
-        "language": "blade",
-        "path": "./snippets/frameworks/blade/blade.json"
-      },
-      {
-        "language": "blade",
-        "path": "./snippets/frameworks/blade/helpers.json"
-      },
-      {
-        "language": "blade",
-        "path": "./snippets/frameworks/blade/livewire.json"
-      },
-      {
-        "language": "blade",
-        "path": "./snippets/frameworks/blade/snippets.json"
-      },
-      {
-        "language": [
-          "r",
-          "rmd"
-        ],
-        "path": "./snippets/r.json"
-      },
-      {
-        "language": "rmd",
-        "path": "./snippets/rmarkdown.json"
-      },
-      {
-        "language": "org",
-        "path": "./snippets/org.json"
-      },
-      {
-        "language": "norg",
-        "path": "./snippets/norg.json"
-      },
-      {
-        "language": "mint",
-        "path": "./snippets/mint.json"
-      },
-      {
-        "language": "gdscript",
-        "path": "./snippets/gdscript.json"
-      },
-      {
-        "language": "yaml",
-        "path": "./snippets/kubernetes.json"
-      },
-      {
-        "language": "yaml",
-        "path": "./snippets/docker/docker-compose.json"
-      },
-      {
-        "language": "make",
-        "path": "./snippets/make.json"
-      },
-      {
-        "language": "dart",
-        "path": "./snippets/dart.json"
-      },
-      {
-        "language": "objc",
-        "path": "./snippets/objc.json"
-      },
-      {
-        "language": "unreal",
-        "path": "./snippets/frameworks/unreal.json"
-      },
-      {
-        "language": "unity",
-        "path": "./snippets/frameworks/unity.json"
-      },
-      {
-        "language": "tcl",
-        "path": "./snippets/tcl.json"
-      },
-      {
-        "language": "verilog",
-        "path": "./snippets/verilog.json"
-      },
-      {
-        "language": "vhdl",
-        "path": "./snippets/vhdl.json"
-      },
-      {
-        "language": "dockerfile",
-        "path": "./snippets/docker/docker_file.json"
-      },
-      {
-        "language": "edge",
-        "path": "./snippets/frameworks/edge.json"
-      },
-      {
-        "language": [
-          "powershell",
-          "ps1"
-        ],
-        "path": "./snippets/PowerShell.json"
-      },
-      {
-        "language": "nu",
-        "path": "./snippets/nushell.json"
-      },
-      {
-        "language": "reason",
-        "path": "./snippets/reason.json"
-      },
-      {
-        "language": [
-          "ocaml",
-          "ocamlinterface"
-        ],
-        "path": "./snippets/ocaml/ocaml.json"
-      },
-      {
-        "language": "ocaml.ocamllex",
-        "path": "./snippets/ocaml/ocamllex.json"
-      },
-      {
-        "language": "dune-project",
-        "path": "./snippets/ocaml/dune-project.json"
-      },
-      {
-        "language": "dune",
-        "path": "./snippets/ocaml/dune.json"
-      }
-    ]
-  }
+    "name": "friendly-snippets",
+    "engines": {
+        "vscode": "^1.11.0"
+    },
+    "contributes": {
+        "snippets": [
+            {
+                "language": [
+                    "plaintext",
+                    "markdown",
+                    "tex",
+                    "html",
+                    "global",
+                    "all"
+                ],
+                "path": "./snippets/global.json"
+            },
+            {
+                "language": ["license"],
+                "path": "./snippets/license.json"
+            },
+            {
+                "language": "c",
+                "path": "./snippets/c/c.json"
+            },
+            {
+                "language": "cdoc",
+                "path": "./snippets/c/cdoc.json"
+            },
+            {
+                "language": "cpp",
+                "path": "./snippets/cpp/cpp.json"
+            },
+            {
+                "language": "cppdoc",
+                "path": "./snippets/cpp/cppdoc.json"
+            },
+            {
+                "language": ["csharp", "cs"],
+                "path": "./snippets/csharp/csharp.json"
+            },
+            {
+                "language": "csharpdoc",
+                "path": "./snippets/csharp/csharpdoc.json"
+            },
+            {
+                "language": ["gitcommit", "NeogitCommitMessage"],
+                "path": "./snippets/gitcommit.json"
+            },
+            {
+                "language": "ejs",
+                "path": "./snippets/frameworks/ejs.json"
+            },
+            {
+                "language": "eruby",
+                "path": "./snippets/erb.json"
+            },
+            {
+                "language": "erlang",
+                "path": "./snippets/erlang.json"
+            },
+            {
+                "language": "elixir",
+                "path": "./snippets/elixir.json"
+            },
+            {
+                "language": ["eelixir", "heex"],
+                "path": "./snippets/eelixir.json"
+            },
+            {
+                "language": "fortran",
+                "path": "./snippets/fortran.json"
+            },
+            {
+                "language": "glsl",
+                "path": "./snippets/glsl.json"
+            },
+            {
+                "language": "nix",
+                "path": "./snippets/nix.json"
+            },
+            {
+                "language": "liquid",
+                "path": "./snippets/liquid.json"
+            },
+            {
+                "language": "lua",
+                "path": "./snippets/lua/lua.json"
+            },
+            {
+                "language": "luadoc",
+                "path": "./snippets/lua/luadoc.json"
+            },
+            {
+                "language": "go",
+                "path": "./snippets/go.json"
+            },
+            {
+                "language": "fennel",
+                "path": "./snippets/fennel.json"
+            },
+            {
+                "language": "fsh",
+                "path": "./snippets/fsh.json"
+            },
+            {
+                "language": "php",
+                "path": "./snippets/php/php.json"
+            },
+            {
+                "language": "phpdoc",
+                "path": "./snippets/php/phpdoc.json"
+            },
+            {
+                "language": "quarto",
+                "path": "./snippets/quarto.json"
+            },
+            {
+                "language": "rescript",
+                "path": "./snippets/rescript.json"
+            },
+            {
+                "language": "ruby",
+                "path": "./snippets/ruby/ruby.json"
+            },
+            {
+                "language": "rdoc",
+                "path": "./snippets/ruby/rdoc.json"
+            },
+            {
+                "language": "rails",
+                "path": "./snippets/frameworks/rails.json"
+            },
+            {
+                "language": "rust",
+                "path": "./snippets/rust/rust.json"
+            },
+            {
+                "language": "rustdoc",
+                "path": "./snippets/rust/rustdoc.json"
+            },
+            {
+                "language": "rust",
+                "path": "./snippets/frameworks/relm4/workers.json"
+            },
+            {
+                "language": "rust",
+                "path": "./snippets/frameworks/relm4/factories.json"
+            },
+            {
+                "language": "rust",
+                "path": "./snippets/frameworks/relm4/templates.json"
+            },
+            {
+                "language": "rust",
+                "path": "./snippets/frameworks/relm4/components.json"
+            },
+            {
+                "language": "haskell",
+                "path": "./snippets/haskell.json"
+            },
+            {
+                "language": "scala",
+                "path": "./snippets/scala.json"
+            },
+            {
+                "language": "solidity",
+                "path": "./snippets/solidity.json"
+            },
+            {
+                "language": "swift",
+                "path": "./snippets/swift.json"
+            },
+            {
+                "language": "sql",
+                "path": "./snippets/sql.json"
+            },
+            {
+                "language": "systemverilog",
+                "path": "./snippets/systemverilog.json"
+            },
+            {
+                "language": ["shellscript", "shell", "sh", "zsh"],
+                "path": "./snippets/shell/shell.json"
+            },
+            {
+                "language": "shelldoc",
+                "path": "./snippets/shell/shelldoc.json"
+            },
+            {
+                "language": ["markdown", "rmd"],
+                "path": "./snippets/markdown.json"
+            },
+            {
+                "language": ["plaintex", "tex"],
+                "path": "./snippets/latex.json"
+            },
+            {
+                "language": "plantuml",
+                "path": "./snippets/plantuml.json"
+            },
+            {
+                "language": "java",
+                "path": "./snippets/java/java.json"
+            },
+            {
+                "language": "java-testing",
+                "path": "./snippets/java/java-tests.json"
+            },
+            {
+                "language": "javadoc",
+                "path": "./snippets/java/javadoc.json"
+            },
+            {
+                "language": "julia",
+                "path": "./snippets/julia.json"
+            },
+            {
+                "language": [
+                    "html",
+                    "jade",
+                    "pug",
+                    "eruby",
+                    "javascriptreact",
+                    "htmldjango",
+                    "astro",
+		    "blade"
+                ],
+                "path": "./snippets/html.json"
+            },
+            {
+                "language": ["css", "scss", "sass", "less", "stylus"],
+                "path": "./snippets/css.json"
+            },
+            {
+                "language": ["javascript", "javascriptreact", "vue", "svelte"],
+                "path": "./snippets/javascript/javascript.json"
+            },
+            {
+                "language": "jsdoc",
+                "path": "./snippets/javascript/jsdoc.json"
+            },
+            {
+                "language": "tsdoc",
+                "path": "./snippets/javascript/tsdoc.json"
+            },
+            {
+                "language": ["typescript", "typescriptreact"],
+                "path": "./snippets/javascript/typescript.json"
+            },
+            {
+                "language": "javascriptreact",
+                "path": "./snippets/javascript/react.json"
+            },
+            {
+                "language": "javascriptreact",
+                "path": "./snippets/javascript/react-native.json"
+            },
+            {
+                "language": "javascriptreact",
+                "path": "./snippets/javascript/next.json"
+            },
+            {
+                "language": "typescriptreact",
+                "path": "./snippets/javascript/react-ts.json"
+            },
+            {
+                "language": "typescriptreact",
+                "path": "./snippets/javascript/next-ts.json"
+            },
+            {
+                "language": "typescriptreact",
+                "path": "./snippets/javascript/react-native-ts.json"
+            },
+            {
+                "language": ["javascriptreact", "typescriptreact"],
+                "path": "./snippets/javascript/react-es7.json"
+            },
+            {
+                "language": "svelte",
+                "path": "./snippets/svelte.json"
+            },
+            {
+                "language": "vue",
+                "path": "./snippets/frameworks/vue/html.json"
+            },
+            {
+                "language": "vue",
+                "path": "./snippets/frameworks/vue/nuxt_html.json"
+            },
+            {
+                "language": "vue",
+                "path": "./snippets/frameworks/vue/nuxt_js_ts.json"
+            },
+            {
+                "language": "vue",
+                "path": "./snippets/frameworks/vue/javascript.json"
+            },
+            {
+                "language": "vue",
+                "path": "./snippets/frameworks/vue/vue.json"
+            },
+            {
+                "language": "angular",
+                "path": "./snippets/frameworks/angular/html.json"
+            },
+            {
+                "language": "angular",
+                "path": "./snippets/frameworks/angular/typescript.json"
+            },
+            {
+                "language": "angular",
+                "path": "./snippets/frameworks/angular/jsonc.json"
+            },
+            {
+                "language": "python",
+                "path": "./snippets/python/base.json"
+            },
+            {
+                "language": "python",
+                "path": "./snippets/python/comprehension.json"
+            },
+            {
+                "language": "python",
+                "path": "./snippets/python/debug.json"
+            },
+            {
+                "language": "python",
+                "path": "./snippets/python/python.json"
+            },
+            {
+                "language": "python",
+                "path": "./snippets/python/unittest.json"
+            },
+            {
+                "language": "pydoc",
+                "path": "./snippets/python/pydoc.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/admin.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/forms.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/models.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/tags.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/urls.json"
+            },
+            {
+                "language": "django",
+                "path": "./snippets/frameworks/django/views.json"
+            },
+            {
+                "language": ["djangohtml", "htmldjango"],
+                "path": "./snippets/frameworks/djangohtml.json"
+            },
+            {
+                "language": "django-rest",
+                "path": "./snippets/frameworks/django/django_rest/serializers.json"
+            },
+            {
+                "language": "django-rest",
+                "path": "./snippets/frameworks/django/django_rest/views.json"
+            },
+            {
+                "language": "flutter",
+                "path": "./snippets/frameworks/flutter.json"
+            },
+            {
+                "language": "jekyll",
+                "path": "./snippets/frameworks/jekyll.json"
+            },
+            {
+                "language": "cobol",
+                "path": "./snippets/cobol/vscode_cobol.json"
+            },
+            {
+                "language": "cobol",
+                "path": "./snippets/cobol/vscode_cobol-compound.json"
+            },
+            {
+                "language": "cobol",
+                "path": "./snippets/cobol/vscode_cobol_dir.json"
+            },
+            {
+                "language": "cobol",
+                "path": "./snippets/cobol/vscode_cobol_jcl.json"
+            },
+            {
+                "language": "kotlin",
+                "path": "./snippets/kotlin/kotlin.json"
+            },
+            {
+                "language": "kdoc",
+                "path": "./snippets/kotlin/kdoc.json"
+            },
+            {
+                "language": ["plaintex", "tex"],
+                "path": "./snippets/latex/latex-snippets.json"
+            },
+            {
+                "language": ["plaintex", "tex"],
+                "path": "./snippets/latex/vscode-latex-snippets.json"
+            },
+            {
+                "language": ["bibtex", "bib"],
+                "path": "./snippets/latex/bibtex.json"
+            },
+            {
+        	"language": "twig",
+                "path": "./snippets/frameworks/twig.json"
+            },
+	    {
+	    	"language": "blade",
+	    	"path": "./snippets/frameworks/blade/blade.json"
+	    },
+	    {
+		"language": "blade",
+		"path": "./snippets/frameworks/blade/helpers.json"
+	    },
+	    {
+		"language": "blade",
+		"path": "./snippets/frameworks/blade/livewire.json"
+	    },
+	    {
+		"language": "blade",
+		"path": "./snippets/frameworks/blade/snippets.json"
+	    },
+            {
+                "language": ["r", "rmd"],
+                "path": "./snippets/r.json"
+            },
+            {
+                "language": "rmd",
+                "path": "./snippets/rmarkdown.json"
+            },
+            {
+                "language": "org",
+                "path": "./snippets/org.json"
+            },
+            {
+                "language": "norg",
+                "path": "./snippets/norg.json"
+            },
+            {
+                "language": "mint",
+                "path": "./snippets/mint.json"
+            },
+            {
+                "language": "gdscript",
+                "path": "./snippets/gdscript.json"
+            },
+            {
+                "language": "yaml",
+                "path": "./snippets/kubernetes.json"
+            },
+            {
+                "language": "yaml",
+                "path": "./snippets/docker/docker-compose.json"
+            },
+            {
+                "language": "make",
+                "path": "./snippets/make.json"
+            },
+            {
+                "language": "dart",
+                "path": "./snippets/dart.json"
+            },
+            {
+                "language": "objc",
+                "path": "./snippets/objc.json"
+            },
+            {
+                "language": "unreal",
+                "path": "./snippets/frameworks/unreal.json"
+            },
+            {
+                "language": "unity",
+                "path": "./snippets/frameworks/unity.json"
+            },
+            {
+                "language": "tcl",
+                "path": "./snippets/tcl.json"
+            },
+            {
+                "language": "verilog",
+                "path": "./snippets/verilog.json"
+            },
+            {
+                "language": "vhdl",
+                "path": "./snippets/vhdl.json"
+            },
+            {
+                "language": "dockerfile",
+                "path": "./snippets/docker/docker_file.json"
+            },
+            {
+                "language": "edge",
+                "path": "./snippets/frameworks/edge.json"
+            },
+            {
+                "language": ["powershell", "ps1"],
+                "path": "./snippets/PowerShell.json"
+            },
+            {
+                "language": "nu",
+                "path": "./snippets/nushell.json"
+            },
+            {
+                "language": "reason",
+                "path": "./snippets/reason.json"
+            },
+            {
+                "language": [
+                    "ocaml",
+                    "ocamlinterface"
+                ],
+                "path": "./snippets/ocaml/ocaml.json"
+            },
+            {
+                "language": "ocaml.ocamllex",
+                "path": "./snippets/ocaml/ocamllex.json"
+            },
+            {
+                "language": "dune-project",
+                "path": "./snippets/ocaml/dune-project.json"
+            },
+            {
+                "language": "dune",
+                "path": "./snippets/ocaml/dune.json"
+            }
+        ]
+    }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,528 +1,602 @@
 {
-    "name": "friendly-snippets",
-    "engines": {
-        "vscode": "^1.11.0"
-    },
-    "contributes": {
-        "snippets": [
-            {
-                "language": [
-                    "plaintext",
-                    "markdown",
-                    "tex",
-                    "html",
-                    "global",
-                    "all"
-                ],
-                "path": "./snippets/global.json"
-            },
-            {
-                "language": ["license"],
-                "path": "./snippets/license.json"
-            },
-            {
-                "language": "c",
-                "path": "./snippets/c/c.json"
-            },
-            {
-                "language": "cdoc",
-                "path": "./snippets/c/cdoc.json"
-            },
-            {
-                "language": "cpp",
-                "path": "./snippets/cpp/cpp.json"
-            },
-            {
-                "language": "cppdoc",
-                "path": "./snippets/cpp/cppdoc.json"
-            },
-            {
-                "language": ["csharp", "cs"],
-                "path": "./snippets/csharp/csharp.json"
-            },
-            {
-                "language": "csharpdoc",
-                "path": "./snippets/csharp/csharpdoc.json"
-            },
-            {
-                "language": ["gitcommit", "NeogitCommitMessage"],
-                "path": "./snippets/gitcommit.json"
-            },
-            {
-                "language": "ejs",
-                "path": "./snippets/frameworks/ejs.json"
-            },
-            {
-                "language": "eruby",
-                "path": "./snippets/erb.json"
-            },
-            {
-                "language": "erlang",
-                "path": "./snippets/erlang.json"
-            },
-            {
-                "language": "elixir",
-                "path": "./snippets/elixir.json"
-            },
-            {
-                "language": ["eelixir", "heex"],
-                "path": "./snippets/eelixir.json"
-            },
-            {
-                "language": "fortran",
-                "path": "./snippets/fortran.json"
-            },
-            {
-                "language": "glsl",
-                "path": "./snippets/glsl.json"
-            },
-            {
-                "language": "nix",
-                "path": "./snippets/nix.json"
-            },
-            {
-                "language": "liquid",
-                "path": "./snippets/liquid.json"
-            },
-            {
-                "language": "lua",
-                "path": "./snippets/lua/lua.json"
-            },
-            {
-                "language": "luadoc",
-                "path": "./snippets/lua/luadoc.json"
-            },
-            {
-                "language": "go",
-                "path": "./snippets/go.json"
-            },
-            {
-                "language": "fennel",
-                "path": "./snippets/fennel.json"
-            },
-            {
-                "language": "fsh",
-                "path": "./snippets/fsh.json"
-            },
-            {
-                "language": "php",
-                "path": "./snippets/php/php.json"
-            },
-            {
-                "language": "phpdoc",
-                "path": "./snippets/php/phpdoc.json"
-            },
-            {
-                "language": "quarto",
-                "path": "./snippets/quarto.json"
-            },
-            {
-                "language": "rescript",
-                "path": "./snippets/rescript.json"
-            },
-            {
-                "language": "ruby",
-                "path": "./snippets/ruby/ruby.json"
-            },
-            {
-                "language": "rdoc",
-                "path": "./snippets/ruby/rdoc.json"
-            },
-            {
-                "language": "rails",
-                "path": "./snippets/frameworks/rails.json"
-            },
-            {
-                "language": "rust",
-                "path": "./snippets/rust/rust.json"
-            },
-            {
-                "language": "rustdoc",
-                "path": "./snippets/rust/rustdoc.json"
-            },
-            {
-                "language": "rust",
-                "path": "./snippets/frameworks/relm4/workers.json"
-            },
-            {
-                "language": "rust",
-                "path": "./snippets/frameworks/relm4/factories.json"
-            },
-            {
-                "language": "rust",
-                "path": "./snippets/frameworks/relm4/templates.json"
-            },
-            {
-                "language": "rust",
-                "path": "./snippets/frameworks/relm4/components.json"
-            },
-            {
-                "language": "haskell",
-                "path": "./snippets/haskell.json"
-            },
-            {
-                "language": "scala",
-                "path": "./snippets/scala.json"
-            },
-            {
-                "language": "solidity",
-                "path": "./snippets/solidity.json"
-            },
-            {
-                "language": "swift",
-                "path": "./snippets/swift.json"
-            },
-            {
-                "language": "sql",
-                "path": "./snippets/sql.json"
-            },
-            {
-                "language": "systemverilog",
-                "path": "./snippets/systemverilog.json"
-            },
-            {
-                "language": ["shellscript", "shell", "sh", "zsh"],
-                "path": "./snippets/shell/shell.json"
-            },
-            {
-                "language": "shelldoc",
-                "path": "./snippets/shell/shelldoc.json"
-            },
-            {
-                "language": ["markdown", "rmd"],
-                "path": "./snippets/markdown.json"
-            },
-            {
-                "language": ["plaintex", "tex"],
-                "path": "./snippets/latex.json"
-            },
-            {
-                "language": "plantuml",
-                "path": "./snippets/plantuml.json"
-            },
-            {
-                "language": "java",
-                "path": "./snippets/java/java.json"
-            },
-            {
-                "language": "java-testing",
-                "path": "./snippets/java/java-tests.json"
-            },
-            {
-                "language": "javadoc",
-                "path": "./snippets/java/javadoc.json"
-            },
-            {
-                "language": "julia",
-                "path": "./snippets/julia.json"
-            },
-            {
-                "language": [
-                    "html",
-                    "jade",
-                    "pug",
-                    "eruby",
-                    "javascriptreact",
-                    "htmldjango",
-                    "astro"
-                ],
-                "path": "./snippets/html.json"
-            },
-            {
-                "language": ["css", "scss", "sass", "less", "stylus"],
-                "path": "./snippets/css.json"
-            },
-            {
-                "language": ["javascript", "javascriptreact", "vue", "svelte"],
-                "path": "./snippets/javascript/javascript.json"
-            },
-            {
-                "language": "jsdoc",
-                "path": "./snippets/javascript/jsdoc.json"
-            },
-            {
-                "language": "tsdoc",
-                "path": "./snippets/javascript/tsdoc.json"
-            },
-            {
-                "language": ["typescript", "typescriptreact"],
-                "path": "./snippets/javascript/typescript.json"
-            },
-            {
-                "language": "javascriptreact",
-                "path": "./snippets/javascript/react.json"
-            },
-            {
-                "language": "javascriptreact",
-                "path": "./snippets/javascript/react-native.json"
-            },
-            {
-                "language": "javascriptreact",
-                "path": "./snippets/javascript/next.json"
-            },
-            {
-                "language": "typescriptreact",
-                "path": "./snippets/javascript/react-ts.json"
-            },
-            {
-                "language": "typescriptreact",
-                "path": "./snippets/javascript/next-ts.json"
-            },
-            {
-                "language": "typescriptreact",
-                "path": "./snippets/javascript/react-native-ts.json"
-            },
-            {
-                "language": ["javascriptreact", "typescriptreact"],
-                "path": "./snippets/javascript/react-es7.json"
-            },
-            {
-                "language": "svelte",
-                "path": "./snippets/svelte.json"
-            },
-            {
-                "language": "vue",
-                "path": "./snippets/frameworks/vue/html.json"
-            },
-            {
-                "language": "vue",
-                "path": "./snippets/frameworks/vue/nuxt_html.json"
-            },
-            {
-                "language": "vue",
-                "path": "./snippets/frameworks/vue/nuxt_js_ts.json"
-            },
-            {
-                "language": "vue",
-                "path": "./snippets/frameworks/vue/javascript.json"
-            },
-            {
-                "language": "vue",
-                "path": "./snippets/frameworks/vue/vue.json"
-            },
-            {
-                "language": "angular",
-                "path": "./snippets/frameworks/angular/html.json"
-            },
-            {
-                "language": "angular",
-                "path": "./snippets/frameworks/angular/typescript.json"
-            },
-            {
-                "language": "angular",
-                "path": "./snippets/frameworks/angular/jsonc.json"
-            },
-            {
-                "language": "python",
-                "path": "./snippets/python/base.json"
-            },
-            {
-                "language": "python",
-                "path": "./snippets/python/comprehension.json"
-            },
-            {
-                "language": "python",
-                "path": "./snippets/python/debug.json"
-            },
-            {
-                "language": "python",
-                "path": "./snippets/python/python.json"
-            },
-            {
-                "language": "python",
-                "path": "./snippets/python/unittest.json"
-            },
-            {
-                "language": "pydoc",
-                "path": "./snippets/python/pydoc.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/admin.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/forms.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/models.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/tags.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/urls.json"
-            },
-            {
-                "language": "django",
-                "path": "./snippets/frameworks/django/views.json"
-            },
-            {
-                "language": ["djangohtml", "htmldjango"],
-                "path": "./snippets/frameworks/djangohtml.json"
-            },
-            {
-                "language": "django-rest",
-                "path": "./snippets/frameworks/django/django_rest/serializers.json"
-            },
-            {
-                "language": "django-rest",
-                "path": "./snippets/frameworks/django/django_rest/views.json"
-            },
-            {
-                "language": "flutter",
-                "path": "./snippets/frameworks/flutter.json"
-            },
-            {
-                "language": "jekyll",
-                "path": "./snippets/frameworks/jekyll.json"
-            },
-            {
-                "language": "cobol",
-                "path": "./snippets/cobol/vscode_cobol.json"
-            },
-            {
-                "language": "cobol",
-                "path": "./snippets/cobol/vscode_cobol-compound.json"
-            },
-            {
-                "language": "cobol",
-                "path": "./snippets/cobol/vscode_cobol_dir.json"
-            },
-            {
-                "language": "cobol",
-                "path": "./snippets/cobol/vscode_cobol_jcl.json"
-            },
-            {
-                "language": "kotlin",
-                "path": "./snippets/kotlin/kotlin.json"
-            },
-            {
-                "language": "kdoc",
-                "path": "./snippets/kotlin/kdoc.json"
-            },
-            {
-                "language": ["plaintex", "tex"],
-                "path": "./snippets/latex/latex-snippets.json"
-            },
-            {
-                "language": ["plaintex", "tex"],
-                "path": "./snippets/latex/vscode-latex-snippets.json"
-            },
-            {
-                "language": ["bibtex", "bib"],
-                "path": "./snippets/latex/bibtex.json"
-            },
-            {
-                "language": "twig",
-                "path": "./snippets/frameworks/twig.json"
-            },
-            {
-                "language": ["r", "rmd"],
-                "path": "./snippets/r.json"
-            },
-            {
-                "language": "rmd",
-                "path": "./snippets/rmarkdown.json"
-            },
-            {
-                "language": "org",
-                "path": "./snippets/org.json"
-            },
-            {
-                "language": "norg",
-                "path": "./snippets/norg.json"
-            },
-            {
-                "language": "mint",
-                "path": "./snippets/mint.json"
-            },
-            {
-                "language": "gdscript",
-                "path": "./snippets/gdscript.json"
-            },
-            {
-                "language": "yaml",
-                "path": "./snippets/kubernetes.json"
-            },
-            {
-                "language": "yaml",
-                "path": "./snippets/docker/docker-compose.json"
-            },
-            {
-                "language": "make",
-                "path": "./snippets/make.json"
-            },
-            {
-                "language": "dart",
-                "path": "./snippets/dart.json"
-            },
-            {
-                "language": "objc",
-                "path": "./snippets/objc.json"
-            },
-            {
-                "language": "unreal",
-                "path": "./snippets/frameworks/unreal.json"
-            },
-            {
-                "language": "unity",
-                "path": "./snippets/frameworks/unity.json"
-            },
-            {
-                "language": "tcl",
-                "path": "./snippets/tcl.json"
-            },
-            {
-                "language": "verilog",
-                "path": "./snippets/verilog.json"
-            },
-            {
-                "language": "vhdl",
-                "path": "./snippets/vhdl.json"
-            },
-            {
-                "language": "dockerfile",
-                "path": "./snippets/docker/docker_file.json"
-            },
-            {
-                "language": "edge",
-                "path": "./snippets/frameworks/edge.json"
-            },
-            {
-                "language": ["powershell", "ps1"],
-                "path": "./snippets/PowerShell.json"
-            },
-            {
-                "language": "nu",
-                "path": "./snippets/nushell.json"
-            },
-            {
-                "language": "reason",
-                "path": "./snippets/reason.json"
-            },
-            {
-                "language": [
-                    "ocaml",
-                    "ocamlinterface"
-                ],
-                "path": "./snippets/ocaml/ocaml.json"
-            },
-            {
-                "language": "ocaml.ocamllex",
-                "path": "./snippets/ocaml/ocamllex.json"
-            },
-            {
-                "language": "dune-project",
-                "path": "./snippets/ocaml/dune-project.json"
-            },
-            {
-                "language": "dune",
-                "path": "./snippets/ocaml/dune.json"
-            }
-        ]
-    }
+  "name": "friendly-snippets",
+  "engines": {
+    "vscode": "^1.11.0"
+  },
+  "contributes": {
+    "snippets": [
+      {
+        "language": [
+          "plaintext",
+          "markdown",
+          "tex",
+          "html",
+          "global",
+          "all"
+        ],
+        "path": "./snippets/global.json"
+      },
+      {
+        "language": [
+          "license"
+        ],
+        "path": "./snippets/license.json"
+      },
+      {
+        "language": "c",
+        "path": "./snippets/c/c.json"
+      },
+      {
+        "language": "cdoc",
+        "path": "./snippets/c/cdoc.json"
+      },
+      {
+        "language": "cpp",
+        "path": "./snippets/cpp/cpp.json"
+      },
+      {
+        "language": "cppdoc",
+        "path": "./snippets/cpp/cppdoc.json"
+      },
+      {
+        "language": [
+          "csharp",
+          "cs"
+        ],
+        "path": "./snippets/csharp/csharp.json"
+      },
+      {
+        "language": "csharpdoc",
+        "path": "./snippets/csharp/csharpdoc.json"
+      },
+      {
+        "language": [
+          "gitcommit",
+          "NeogitCommitMessage"
+        ],
+        "path": "./snippets/gitcommit.json"
+      },
+      {
+        "language": "ejs",
+        "path": "./snippets/frameworks/ejs.json"
+      },
+      {
+        "language": "eruby",
+        "path": "./snippets/erb.json"
+      },
+      {
+        "language": "erlang",
+        "path": "./snippets/erlang.json"
+      },
+      {
+        "language": "elixir",
+        "path": "./snippets/elixir.json"
+      },
+      {
+        "language": [
+          "eelixir",
+          "heex"
+        ],
+        "path": "./snippets/eelixir.json"
+      },
+      {
+        "language": "fortran",
+        "path": "./snippets/fortran.json"
+      },
+      {
+        "language": "glsl",
+        "path": "./snippets/glsl.json"
+      },
+      {
+        "language": "nix",
+        "path": "./snippets/nix.json"
+      },
+      {
+        "language": "liquid",
+        "path": "./snippets/liquid.json"
+      },
+      {
+        "language": "lua",
+        "path": "./snippets/lua/lua.json"
+      },
+      {
+        "language": "luadoc",
+        "path": "./snippets/lua/luadoc.json"
+      },
+      {
+        "language": "go",
+        "path": "./snippets/go.json"
+      },
+      {
+        "language": "fennel",
+        "path": "./snippets/fennel.json"
+      },
+      {
+        "language": "fsh",
+        "path": "./snippets/fsh.json"
+      },
+      {
+        "language": "php",
+        "path": "./snippets/php/php.json"
+      },
+      {
+        "language": "phpdoc",
+        "path": "./snippets/php/phpdoc.json"
+      },
+      {
+        "language": "quarto",
+        "path": "./snippets/quarto.json"
+      },
+      {
+        "language": "rescript",
+        "path": "./snippets/rescript.json"
+      },
+      {
+        "language": "ruby",
+        "path": "./snippets/ruby/ruby.json"
+      },
+      {
+        "language": "rdoc",
+        "path": "./snippets/ruby/rdoc.json"
+      },
+      {
+        "language": "rails",
+        "path": "./snippets/frameworks/rails.json"
+      },
+      {
+        "language": "rust",
+        "path": "./snippets/rust/rust.json"
+      },
+      {
+        "language": "rustdoc",
+        "path": "./snippets/rust/rustdoc.json"
+      },
+      {
+        "language": "rust",
+        "path": "./snippets/frameworks/relm4/workers.json"
+      },
+      {
+        "language": "rust",
+        "path": "./snippets/frameworks/relm4/factories.json"
+      },
+      {
+        "language": "rust",
+        "path": "./snippets/frameworks/relm4/templates.json"
+      },
+      {
+        "language": "rust",
+        "path": "./snippets/frameworks/relm4/components.json"
+      },
+      {
+        "language": "haskell",
+        "path": "./snippets/haskell.json"
+      },
+      {
+        "language": "scala",
+        "path": "./snippets/scala.json"
+      },
+      {
+        "language": "solidity",
+        "path": "./snippets/solidity.json"
+      },
+      {
+        "language": "swift",
+        "path": "./snippets/swift.json"
+      },
+      {
+        "language": "sql",
+        "path": "./snippets/sql.json"
+      },
+      {
+        "language": "systemverilog",
+        "path": "./snippets/systemverilog.json"
+      },
+      {
+        "language": [
+          "shellscript",
+          "shell",
+          "sh",
+          "zsh"
+        ],
+        "path": "./snippets/shell/shell.json"
+      },
+      {
+        "language": "shelldoc",
+        "path": "./snippets/shell/shelldoc.json"
+      },
+      {
+        "language": [
+          "markdown",
+          "rmd"
+        ],
+        "path": "./snippets/markdown.json"
+      },
+      {
+        "language": [
+          "plaintex",
+          "tex"
+        ],
+        "path": "./snippets/latex.json"
+      },
+      {
+        "language": "plantuml",
+        "path": "./snippets/plantuml.json"
+      },
+      {
+        "language": "java",
+        "path": "./snippets/java/java.json"
+      },
+      {
+        "language": "java-testing",
+        "path": "./snippets/java/java-tests.json"
+      },
+      {
+        "language": "javadoc",
+        "path": "./snippets/java/javadoc.json"
+      },
+      {
+        "language": "julia",
+        "path": "./snippets/julia.json"
+      },
+      {
+        "language": [
+          "html",
+          "jade",
+          "pug",
+          "eruby",
+          "javascriptreact",
+          "htmldjango",
+          "astro",
+          "blade"
+        ],
+        "path": "./snippets/html.json"
+      },
+      {
+        "language": [
+          "css",
+          "scss",
+          "sass",
+          "less",
+          "stylus"
+        ],
+        "path": "./snippets/css.json"
+      },
+      {
+        "language": [
+          "javascript",
+          "javascriptreact",
+          "vue",
+          "svelte"
+        ],
+        "path": "./snippets/javascript/javascript.json"
+      },
+      {
+        "language": "jsdoc",
+        "path": "./snippets/javascript/jsdoc.json"
+      },
+      {
+        "language": "tsdoc",
+        "path": "./snippets/javascript/tsdoc.json"
+      },
+      {
+        "language": [
+          "typescript",
+          "typescriptreact"
+        ],
+        "path": "./snippets/javascript/typescript.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/javascript/react.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/javascript/react-native.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/javascript/next.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/javascript/react-ts.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/javascript/next-ts.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/javascript/react-native-ts.json"
+      },
+      {
+        "language": [
+          "javascriptreact",
+          "typescriptreact"
+        ],
+        "path": "./snippets/javascript/react-es7.json"
+      },
+      {
+        "language": "svelte",
+        "path": "./snippets/svelte.json"
+      },
+      {
+        "language": "vue",
+        "path": "./snippets/frameworks/vue/html.json"
+      },
+      {
+        "language": "vue",
+        "path": "./snippets/frameworks/vue/nuxt_html.json"
+      },
+      {
+        "language": "vue",
+        "path": "./snippets/frameworks/vue/nuxt_js_ts.json"
+      },
+      {
+        "language": "vue",
+        "path": "./snippets/frameworks/vue/javascript.json"
+      },
+      {
+        "language": "vue",
+        "path": "./snippets/frameworks/vue/vue.json"
+      },
+      {
+        "language": "angular",
+        "path": "./snippets/frameworks/angular/html.json"
+      },
+      {
+        "language": "angular",
+        "path": "./snippets/frameworks/angular/typescript.json"
+      },
+      {
+        "language": "angular",
+        "path": "./snippets/frameworks/angular/jsonc.json"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/python/base.json"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/python/comprehension.json"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/python/debug.json"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/python/python.json"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/python/unittest.json"
+      },
+      {
+        "language": "pydoc",
+        "path": "./snippets/python/pydoc.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/admin.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/forms.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/models.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/tags.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/urls.json"
+      },
+      {
+        "language": "django",
+        "path": "./snippets/frameworks/django/views.json"
+      },
+      {
+        "language": [
+          "djangohtml",
+          "htmldjango"
+        ],
+        "path": "./snippets/frameworks/djangohtml.json"
+      },
+      {
+        "language": "django-rest",
+        "path": "./snippets/frameworks/django/django_rest/serializers.json"
+      },
+      {
+        "language": "django-rest",
+        "path": "./snippets/frameworks/django/django_rest/views.json"
+      },
+      {
+        "language": "flutter",
+        "path": "./snippets/frameworks/flutter.json"
+      },
+      {
+        "language": "jekyll",
+        "path": "./snippets/frameworks/jekyll.json"
+      },
+      {
+        "language": "cobol",
+        "path": "./snippets/cobol/vscode_cobol.json"
+      },
+      {
+        "language": "cobol",
+        "path": "./snippets/cobol/vscode_cobol-compound.json"
+      },
+      {
+        "language": "cobol",
+        "path": "./snippets/cobol/vscode_cobol_dir.json"
+      },
+      {
+        "language": "cobol",
+        "path": "./snippets/cobol/vscode_cobol_jcl.json"
+      },
+      {
+        "language": "kotlin",
+        "path": "./snippets/kotlin/kotlin.json"
+      },
+      {
+        "language": "kdoc",
+        "path": "./snippets/kotlin/kdoc.json"
+      },
+      {
+        "language": [
+          "plaintex",
+          "tex"
+        ],
+        "path": "./snippets/latex/latex-snippets.json"
+      },
+      {
+        "language": [
+          "plaintex",
+          "tex"
+        ],
+        "path": "./snippets/latex/vscode-latex-snippets.json"
+      },
+      {
+        "language": [
+          "bibtex",
+          "bib"
+        ],
+        "path": "./snippets/latex/bibtex.json"
+      },
+      {
+        "language": "twig",
+        "path": "./snippets/frameworks/twig.json"
+      },
+      {
+        "language": "blade",
+        "path": "./snippets/frameworks/blade/blade.json"
+      },
+      {
+        "language": "blade",
+        "path": "./snippets/frameworks/blade/helpers.json"
+      },
+      {
+        "language": "blade",
+        "path": "./snippets/frameworks/blade/livewire.json"
+      },
+      {
+        "language": "blade",
+        "path": "./snippets/frameworks/blade/snippets.json"
+      },
+      {
+        "language": [
+          "r",
+          "rmd"
+        ],
+        "path": "./snippets/r.json"
+      },
+      {
+        "language": "rmd",
+        "path": "./snippets/rmarkdown.json"
+      },
+      {
+        "language": "org",
+        "path": "./snippets/org.json"
+      },
+      {
+        "language": "norg",
+        "path": "./snippets/norg.json"
+      },
+      {
+        "language": "mint",
+        "path": "./snippets/mint.json"
+      },
+      {
+        "language": "gdscript",
+        "path": "./snippets/gdscript.json"
+      },
+      {
+        "language": "yaml",
+        "path": "./snippets/kubernetes.json"
+      },
+      {
+        "language": "yaml",
+        "path": "./snippets/docker/docker-compose.json"
+      },
+      {
+        "language": "make",
+        "path": "./snippets/make.json"
+      },
+      {
+        "language": "dart",
+        "path": "./snippets/dart.json"
+      },
+      {
+        "language": "objc",
+        "path": "./snippets/objc.json"
+      },
+      {
+        "language": "unreal",
+        "path": "./snippets/frameworks/unreal.json"
+      },
+      {
+        "language": "unity",
+        "path": "./snippets/frameworks/unity.json"
+      },
+      {
+        "language": "tcl",
+        "path": "./snippets/tcl.json"
+      },
+      {
+        "language": "verilog",
+        "path": "./snippets/verilog.json"
+      },
+      {
+        "language": "vhdl",
+        "path": "./snippets/vhdl.json"
+      },
+      {
+        "language": "dockerfile",
+        "path": "./snippets/docker/docker_file.json"
+      },
+      {
+        "language": "edge",
+        "path": "./snippets/frameworks/edge.json"
+      },
+      {
+        "language": [
+          "powershell",
+          "ps1"
+        ],
+        "path": "./snippets/PowerShell.json"
+      },
+      {
+        "language": "nu",
+        "path": "./snippets/nushell.json"
+      },
+      {
+        "language": "reason",
+        "path": "./snippets/reason.json"
+      },
+      {
+        "language": [
+          "ocaml",
+          "ocamlinterface"
+        ],
+        "path": "./snippets/ocaml/ocaml.json"
+      },
+      {
+        "language": "ocaml.ocamllex",
+        "path": "./snippets/ocaml/ocamllex.json"
+      },
+      {
+        "language": "dune-project",
+        "path": "./snippets/ocaml/dune-project.json"
+      },
+      {
+        "language": "dune",
+        "path": "./snippets/ocaml/dune.json"
+      }
+    ]
+  }
 }

--- a/snippets/frameworks/blade/blade.json
+++ b/snippets/frameworks/blade/blade.json
@@ -1,0 +1,49 @@
+{
+  "Blade-component": {
+    "prefix": "Blade::component",
+    "body": "Blade::component('${1:package-name}', ${2:PackageNameComponent}::class);",
+    "description": "Registering Package Components (AppServiceProvider boot method)"
+  },
+  "Blade-include": {
+    "prefix": "Blade::include",
+    "body": "Blade::include('${1:includes.input}', '${2:input}');",
+    "description": "Aliasing Includes (AppServiceProvider boot method)"
+  },
+  "Blade-if": {
+    "prefix": "Blade::if",
+    "body": [
+      "Blade::if('${1:env}', function ($${2:environment}) {",
+      "    ${3:return app()->environment($$environment);}",
+      "});"
+    ],
+    "description": "Custom If Statements (AppServiceProvider boot method)"
+  },
+  "Blade-directive": {
+    "prefix": "Blade::directive",
+    "body": [
+      "Blade::directive('${1:datetime}', function ($${2:expression}) {",
+      "    ${3:return \"<?php echo ($$expression)->format('m/d/Y H:i'); ?>\";}",
+      "});"
+    ],
+    "description": "Custom directive (AppServiceProvider boot method)"
+  },
+  "Blade-stringable": {
+    "prefix": "Blade::stringable",
+    "body": [
+      "Blade::stringable(function (${1:Money} $${2:money}) {",
+      "    ${3:return $$money->formatTo('en_GB');}",
+      "});"
+    ],
+    "description": "Custom echo handlers (AppServiceProvider boot method)"
+  },
+  "Blade-render": {
+    "prefix": "Blade::render",
+    "body": "Blade::render(${1:'Blade template string'}, ${2:\\$data});",
+    "description": "Transform a raw Blade template string into valid HTML (Laravel 9.x)"
+  },
+  "Blade-renderComponent": {
+    "prefix": "Blade::renderComponent",
+    "body": "Blade::renderComponent(new ${1:HelloComponent}(${2:\\$params}));",
+    "description": "Render a given class component by passing the component instance to the method  (Laravel 9.x)"
+  }
+}

--- a/snippets/frameworks/blade/helpers.json
+++ b/snippets/frameworks/blade/helpers.json
@@ -1,0 +1,57 @@
+{
+  "Path-elixir": {
+    "prefix": "lv:elixir",
+    "body": "{{ elixir('${1:file}') }}",
+    "description": "(deprecated) elixir path"
+  },
+  "Path-mix": {
+    "prefix": "lv:mix",
+    "body": "{{ mix('${1:file}') }}",
+    "description": "mix path"
+  },
+  "String-trans": {
+    "prefix": "lv:trans",
+    "body": "{{ trans('$1') }}",
+    "description": "trans"
+  },
+  "URL-action": {
+    "prefix": "lv:action",
+    "body": "{{ action('${1:ControllerName}', [${2:'id'=>1}]) }}",
+    "description": "URL-action"
+  },
+  "URL-secure-asset": {
+    "prefix": "lv:secure-asset",
+    "body": "{{ secure_asset('$1', ${2:\\$title}, ${3:\\$attributes=[]}) }}",
+    "description": "URL-secure-asset"
+  },
+  "URL-url": {
+    "prefix": "lv:url",
+    "body": "{{ url('${1:url}', [$2]) }}",
+    "description": "URL-url"
+  },
+  "URL-asset": {
+    "prefix": "lv:asset",
+    "body": "{{ asset('$1') }}",
+    "description": "URL-asset"
+  },
+  "URL-route": {
+    "prefix": "lv:route",
+    "body": "{{ route('${1:routeName}', [${2:'id'=>1}]) }}",
+    "description": "URL-route"
+  },
+  "Form-csrf-field": {
+    "prefix": "lv:csrf-field",
+    "body": "{{ csrf_field() }}",
+    "description": "CSRF hidden field"
+  },
+  "csrf-token": {
+    "prefix": "lv:csrf-token",
+    "body": "{{ csrf_token() }}",
+    "description": "CSRF token"
+  },
+  "Paginate-links": {
+    "prefix": "lv:pagination-links",
+    "body": "{{ \\$${1:collection}->links() }}",
+    "description": "pagination links"
+  }
+}

--- a/snippets/frameworks/blade/livewire.json
+++ b/snippets/frameworks/blade/livewire.json
@@ -1,0 +1,17 @@
+{
+  "livewireStyles": {
+    "prefix": "livewire:styles",
+    "body": "@livewireStyles",
+    "description": "Livewire Styles directive"
+  },
+  "livewireScripts": {
+    "prefix": "livewire:scripts",
+    "body": "@livewireScripts",
+    "description": "Livewire Scripts directive"
+  },
+  "livewire-component": {
+    "prefix": "livewire:component",
+    "body": "@livewire('${1:component}', ['${2:user}' => \\$${3:user}]${4:, key(\\$$3->id)})",
+    "description": "Livewire nesting components"
+  }
+}

--- a/snippets/frameworks/blade/snippets.json
+++ b/snippets/frameworks/blade/snippets.json
@@ -1,0 +1,488 @@
+{
+  "Extend layout": {
+    "prefix": "b:extends",
+    "body": "@extends('${1:name}')",
+    "description": "extends view layout"
+  },
+  "Yield content": {
+    "prefix": "b:yield",
+    "body": "@yield('${1:name}')",
+    "description": "yield content section"
+  },
+  "Content Section": {
+    "prefix": "b:section",
+    "body": [
+      "@section('${1:name}')",
+      "    $2",
+      "@endsection"
+    ],
+    "description": "content section"
+  },
+  "Content Section Show": {
+    "prefix": "b:section-show",
+    "body": [
+      "@section('$1')",
+      "    $2",
+      "@show"
+    ],
+    "description": "content section show"
+  },
+  "Include view": {
+    "prefix": "b:include",
+    "body": "@include('${1:name}')",
+    "description": "include view"
+  },
+  "If-block": {
+    "prefix": "b:if",
+    "body": [
+      "@if ($1)",
+      "    $2",
+      "@endif"
+    ],
+    "description": "@if block"
+  },
+  "If-else-block": {
+    "prefix": "b:if-else",
+    "body": [
+      "@if ($1)",
+      "    $2",
+      "@else",
+      "    $3",
+      "@endif"
+    ],
+    "description": "if-else block"
+  },
+  "Has Section": {
+    "prefix": "b:has-section",
+    "body": [
+      "@hasSection ('${1:name}')",
+      "    $2",
+      "@else",
+      "    $3",
+      "@endif"
+    ],
+    "description": "@hasSection condition"
+  },
+  "Unless-block": {
+    "prefix": "b:unless",
+    "body": [
+      "@unless ($1)",
+      "    $2",
+      "@endunless"
+    ],
+    "description": "@unless block"
+  },
+  "For-block": {
+    "prefix": "b:for",
+    "body": [
+      "@for (\\$i = ${1:0}; \\$i < ${2:\\$count}; \\$i++)",
+      "    $3",
+      "@endfor"
+    ],
+    "description": "@for block"
+  },
+  "Foreach-block": {
+    "prefix": "b:foreach",
+    "body": [
+      "@foreach (${1:\\$collection} as ${2:\\$item})",
+      "    $3",
+      "@endforeach"
+    ],
+    "description": "@foreach block"
+  },
+  "forelse-block": {
+    "prefix": "b:forelse",
+    "body": [
+      "@forelse (${1:\\$collection} as ${2:\\$item})",
+      "    $3",
+      "@empty",
+      "    $4",
+      "@endforelse"
+    ],
+    "description": "@forelse block"
+  },
+  "while-block": {
+    "prefix": "b:while",
+    "body": [
+      "@while ($1)",
+      "    $2",
+      "@endwhile"
+    ],
+    "description": "@while block"
+  },
+  "each loop": {
+    "prefix": "b:each",
+    "body": "@each('${1:view.name}', ${2:\\$collection}, '${3:variable}', '${4:view.empty}')",
+    "description": "@each loop"
+  },
+  "blade comment": {
+    "prefix": "b:comment",
+    "body": "{{-- ${1:comment} --}}",
+    "description": "comment block"
+  },
+  "blade echo-data": {
+    "prefix": "b:echo",
+    "body": "{{ ${1:\\$data} }}",
+    "description": "echo data"
+  },
+  "blade echo-unescaped-data": {
+    "prefix": "b:echo-html",
+    "body": "{!! ${1:\\$html_data} !!}",
+    "description": "echo unescaped data (allow html outputs)"
+  },
+  "blade echo-untouch": {
+    "prefix": "b:echo-raw",
+    "body": "@{{ ${1:variable} }}",
+    "description": "echo untouched data (allow javascript expression)"
+  },
+  "blade verbatim": {
+    "prefix": "b:verbatim",
+    "body": [
+      "@verbatim",
+      "{{ ${1:variable} }}",
+      "@endverbatim"
+    ],
+    "description": "displaying JavaScript variables in a large portion of your template"
+  },
+  "Push stack": {
+    "prefix": "b:push",
+    "body": [
+      "@push('${1:name}')",
+      "    $2",
+      "@endpush"
+    ],
+    "description": "@push stack"
+  },
+  "Stack": {
+    "prefix": "b:stack",
+    "body": "@stack('${1:name}')",
+    "description": "@stack"
+  },
+  "inject service": {
+    "prefix": "b:inject",
+    "body": "@inject('${1:name}', '${2:class}')",
+    "description": "@inject Service"
+  },
+  "can": {
+    "prefix": "b:can",
+    "body": [
+      "@can('${1:update}', ${2:\\$post})",
+      "    $3",
+      "@endcan"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "can-elsecan": {
+    "prefix": "b:can-elsecan",
+    "body": [
+      "@can('${1:update}', ${2:\\$post})",
+      "    $3",
+      "@elsecan('create', App\\Models\\\\${4:Post}::class)",
+      "    $5",
+      "@endcan"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "canany": {
+    "prefix": "b:canany",
+    "body": [
+      "@canany(['update', 'view', 'delete'], ${1:\\$post})",
+      "    $2",
+      "@endcanany"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "canany-elsecanany": {
+    "prefix": "b:canany-elsecanany",
+    "body": [
+      "@canany(['update', 'view', 'delete'], ${1:\\$post})",
+      "    $2",
+      "@elsecanany(['create'], App\\Models\\\\${3:Post}::class)",
+      "    $4",
+      "@endcanany"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "cannot": {
+    "prefix": "b:cannot",
+    "body": [
+      "@cannot('${1:update}', ${2:\\$post})",
+      "    $3",
+      "@endcannot"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "cannot-elsecannot": {
+    "prefix": "b:cannot-elsecannot",
+    "body": [
+      "@cannot('${1:update}', ${2:\\$post})",
+      "    $3",
+      "@elsecannot('create', App\\Models\\\\${5:Post}::class)",
+      "    $6",
+      "@endcannot"
+    ],
+    "description": "display a portion of the page only if the user is authorized to perform a given action."
+  },
+  "loop": {
+    "prefix": "b:loop",
+    "body": [
+      "\\$loop->${1:first}"
+    ],
+    "description": "$loop->(index|remaining|count|first|last|depth|parent)"
+  },
+  "loop first": {
+    "prefix": "b:loop-first",
+    "body": [
+      "@if (\\$loop->first)",
+      "    ${1:{{-- This is the first iteration --\\}\\}}",
+      "@endif"
+    ],
+    "description": "$loop->first"
+  },
+  "loop last": {
+    "prefix": "b:loop-last",
+    "body": [
+      "@if (\\$loop->last)",
+      "    ${1:{{-- This is the last iteration --\\}\\}}",
+      "@endif"
+    ],
+    "description": "$loop->last"
+  },
+  "php": {
+    "prefix": "b:php",
+    "body": [
+      "@php",
+      "    $1",
+      "@endphp"
+    ],
+    "description": "@php block code in view"
+  },
+  "includeIf": {
+    "prefix": "b:includeIf",
+    "body": "@includeIf('${1:view.name}'${2:, ['some' => 'data']})",
+    "description": "include a view that may or may not be present, you should use the @includeIf directive"
+  },
+  "component": {
+    "prefix": "b:component",
+    "body": [
+      "@component('$1')",
+      "    $2",
+      "@endcomponent"
+    ],
+    "description": "component"
+  },
+  "slot": {
+    "prefix": "b:slot",
+    "body": [
+      "@slot('$1')",
+      "    $2",
+      "@endslot"
+    ],
+    "description": "slot"
+  },
+  "isset": {
+    "prefix": "b:isset",
+    "body": [
+      "@isset(${1:\\$record})",
+      "    $2",
+      "@endisset"
+    ],
+    "description": "isset"
+  },
+  "empty": {
+    "prefix": "b:empty",
+    "body": [
+      "@empty(${1:\\$record})",
+      "    $2",
+      "@endempty"
+    ],
+    "description": "empty"
+  },
+  "error": {
+    "prefix": "b:error",
+    "body": [
+      "@error('${1:record}')",
+      "    $2",
+      "@enderror"
+    ],
+    "description": "error"
+  },
+  "includeWhen": {
+    "prefix": "b:includeWhen",
+    "body": "@includeWhen(${1:\\$boolean}, '${2:view.name}', [${3:'some' => 'data'}])",
+    "description": "includeWhen"
+  },
+  "auth": {
+    "prefix": "b:auth",
+    "body": [
+      "@auth",
+      "    $1",
+      "@endauth"
+    ],
+    "description": "auth"
+  },
+  "guest": {
+    "prefix": "b:guest",
+    "body": [
+      "@guest",
+      "    $1",
+      "@endguest"
+    ],
+    "description": "guest"
+  },
+  "switch": {
+    "prefix": "b:switch",
+    "body": [
+      "@switch(${1:\\$type})",
+      "    @case(${2:1})",
+      "        $3",
+      "        @break",
+      "    @case(${4:2})",
+      "        $5",
+      "        @break",
+      "    @default",
+      "        $6",
+      "@endswitch"
+    ],
+    "description": "switch"
+  },
+  "includeFirst": {
+    "prefix": "b:includeFirst",
+    "body": "@includeFirst(['${1:view.name}', '${2:variable}'], [${3:'some' => 'data'}])",
+    "description": "includeFirst"
+  },
+  "csrf": {
+    "prefix": "b:csrf",
+    "body": "@csrf",
+    "description": "form csrf field"
+  },
+  "method": {
+    "prefix": "b:method",
+    "body": "@method($1)",
+    "description": "form method field"
+  },
+  "dump": {
+    "prefix": "b:dump",
+    "body": "@dump($1)",
+    "description": "dump"
+  },
+  "dd": {
+    "prefix": "b:dd",
+    "body": "@dd($1)",
+    "description": "dump and die"
+  },
+  "lang": {
+    "prefix": "b:lang",
+    "body": "@lang('${1:messages.welcome}')",
+    "description": "lang"
+  },
+  "includeUnless": {
+    "prefix": "b:includeUnless",
+    "body": "@includeUnless(${1:\\$boolean}, '${2:view.name}', [${3:'some' => 'data'}])",
+    "description": "includeUnless"
+  },
+  "props": {
+    "prefix": "b:props",
+    "body": "@props(['${1:propName}'])",
+    "description": "Blade component data properties"
+  },
+  "env": {
+    "prefix": "b:env",
+    "body": [
+      "@env('${1:staging}')",
+      "    $2",
+      "@endenv"
+    ],
+    "description": "env"
+  },
+  "production": {
+    "prefix": "b:production",
+    "body": [
+      "@production",
+      "    $1",
+      "@endproduction"
+    ],
+    "description": "production"
+  },
+  "once": {
+    "prefix": "b:once",
+    "body": [
+      "@once",
+      "    $1",
+      "@endonce"
+    ],
+    "description": "define a portion of template that will only be evaluated once per rendering cycle"
+  },
+  "aware": {
+    "prefix": "b:aware",
+    "body": "@aware(['${1:propName}'])",
+    "description": "Accessing data from a parent component (Laravel 8.64)"
+  },
+  "js": {
+    "prefix": "b:js",
+    "body": "@js(${1:\\$data})",
+    "description": "This directive is useful to properly escape JSON within HTML quotes"
+  },
+  "class": {
+    "prefix": "b:class",
+    "body": "@class(['${1:p-4}', ${2:'font-bold' => true}])",
+    "description": "conditionally compiles a CSS class string. (Laravel 8.51)"
+  },
+  "checked": {
+    "prefix": "b:checked",
+    "body": "@checked(${1:true})",
+    "description": "This directive will echo checked if the provided condition evaluates to true (Laravel 9.x)"
+  },
+  "selected": {
+    "prefix": "b:selected",
+    "body": "@selected(${1:true})",
+    "description": "The @selected directive may be used to indicate if a given select option should be \"selected\" (Laravel 9.x)"
+  },
+  "disabled": {
+    "prefix": "b:disabled",
+    "body": "@disabled(${1:true})",
+    "description": "The @disabled directive may be used to indicate if a given element should be \"disabled\" (Laravel 9.x)"
+  },
+  "style": {
+    "prefix": "b:style",
+    "body": "@style($1)",
+    "description": "The @style directive may be used to conditionally add inline CSS styles to an HTML element (Laravel 9.x)"
+  },
+  "readonly": {
+    "prefix": "b:readonly",
+    "body": "@readonly(${1:true})",
+    "description": "The @readonly directive may be used to indicate if a given element should be \"readonly\" (Laravel 9.x)"
+  },
+  "required": {
+    "prefix": "b:required",
+    "body": "@required(${1:true})",
+    "description": "The @required directive may be used to indicate if a given element should be \"required\" (Laravel 9.x)"
+  },
+  "pushOnce": {
+    "prefix": "b:pushOnce",
+    "body": [
+      "@pushOnce('${1:scripts}')",
+      "    $2",
+      "@endPushOnce"
+    ],
+    "description": "Combine @once and @push for convenience (Laravel 9.x)"
+  },
+  "prepend": {
+    "prefix": "b:prepend",
+    "body": [
+      "@prepend('${1:scripts}')",
+      "    $2",
+      "@prepend"
+    ],
+    "description": "prepend content to a stack"
+  },
+  "prependOnce": {
+    "prefix": "b:prependOnce",
+    "body": [
+      "@prependOnce('${1:scripts}')",
+      "    $2",
+      "@endPrependOnce"
+    ],
+    "description": "Combine @once and @prepend for convenience (Laravel 9.x)"
+  }
+}


### PR DESCRIPTION
Hi,
I sorry I forgot about this as I do not often work with Laravel,
I had raised the issue #299 a few month ago. I re-forked the repository and added the blade snippets.
I ran a new minimal Neovim instance and it seems to work for me.
If I recall they are taken from the vscode repo 
https://github.com/onecentlin/laravel-blade-snippets-vscode/tree/master/snippets.
Hope this can improve Laravel devs experience on Vim.
Kind regards