### PR TITLE
changed c++ cout to a more efficient and polyvalent snippet

### DIFF
--- a/snippets/cpp/cpp.json
+++ b/snippets/cpp/cpp.json
@@ -204,7 +204,7 @@
     },
     "cout": {
         "prefix": "cout",
-        "body": ["std::cout << \"${1:message}\" << std::endl;"],
+        "body": ["std::cout << ${1:message};"],
         "description": "Code snippet for printing to std::cout, provided the header is set"
     },
     "cin": {


### PR DESCRIPTION
the main use cases for cout is debugging which is mostly composed of outing variables not string, std::endl write '\n' and flush the stream which cause a unnecessary performance overhead in most of the cases