### PR TITLE
Add rfcv for React, compatible with Vite

### DIFF
--- a/snippets/javascript/react-es7.json
+++ b/snippets/javascript/react-es7.json
@@ -488,6 +488,18 @@
         ],
         "description": "Creates a React Functional Component with ES7 module system"
     },
+    "reactFunctionalViteComponent": {
+        "prefix": "rfcv",
+        "body": [
+            "export default function ${1:${TM_FILENAME_BASE}}() {",
+            "  return (",
+            "    <div>${1:first}</div>",
+            "  )",
+            "}",
+            ""
+        ],
+        "description": "Creates a React Functional Component with ES7 module system, compatible with Vite"
+    },
     "reactFunctionalComponentRedux": {
         "prefix": "rfcredux",
         "body": [


### PR DESCRIPTION
In the specific case of Vite, there's no need to import React.

- rfcv is included in case someone needs the original option without Vite.