### PR TITLE
Add PureScript snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -526,6 +526,10 @@
             {
                 "language": "dune",
                 "path": "./snippets/ocaml/dune.json"
+            },
+            {
+                "language": "purescript",
+                "path": "./snippets/purescript.json"
             }
         ]
     }

--- a/snippets/purescript.json
+++ b/snippets/purescript.json
@@ -1,0 +1,91 @@
+{
+  "ado": {
+    "body": [
+      "ado",
+      "  ${1:binder} ← ${2:expression}",
+      "",
+      "  in ${3:experssion}"
+    ],
+    "description": "Ado-block",
+    "prefix": [
+      "ado"
+    ]
+  },
+  "case": {
+    "body": [
+      "case ${1:expression} of",
+      "  ${2:case1} → ${3:result}",
+      "  ${4:case2} → ${5:result}$0"
+    ],
+    "description": "Case statement",
+    "prefix": [
+      "case"
+    ]
+  },
+  "derive-instance": {
+    "body": [
+      "derive instance ${1:type}"
+    ],
+    "description": "Derive instance",
+    "prefix": [
+      "derive",
+      "drv"
+    ]
+  },
+  "derive-newtype-instance": {
+    "body": [
+      "derive newtype instance ${1:type}"
+    ],
+    "description": "Derive newtype instance",
+    "prefix": [
+      "derive-newtype",
+      "drvnt",
+      "dni"
+    ]
+  },
+  "do": {
+    "body": [
+      "do",
+      "  ${1:binder} ← ${2:expression}"
+    ],
+    "description": "Do-block",
+    "prefix": [
+      "do"
+    ]
+  },
+  "foreign-import": {
+    "body": [
+      "foreign import ${1:name} ∷ ${2:type}"
+    ],
+    "description": "Foreign import",
+    "prefix": [
+      "foreign",
+      "fri"
+    ]
+  },
+  "foreign-import-data": {
+    "body": [
+      "foreign import data ${1:name} ∷ ${2:kind}"
+    ],
+    "description": "Foreign import data",
+    "prefix": [
+      "foreign-data",
+      "frd"
+    ]
+  },
+  "open-row-type-alias": {
+    "body": [
+      "type ${1:type} r =",
+      "  ( ${2:field} ∷ ${3:type}",
+      "  , ${4:field} ∷ ${5:type}",
+      "  | r",
+      "  )"
+    ],
+    "description": "Type alias for an open row",
+    "prefix": [
+      "open-row-type-alias",
+      "rta",
+      "row"
+    ]
+  }
+}


### PR DESCRIPTION
I couldn't find any contributing guidelines so the snippets I included are tailored towards my own usage. Compared to Haskell (a very similar language) snippets, these:
- Use 2 spaces instead of tabs
- Use unicode
- Don't include short snippets which I believe are easier to type manually anyways

Tabs are almost never used in PureScript. Unicode symbols are about as prevalent as their ASCII counterparts. Either way, if a user has other preferences it would be solved by a formatter.
