### PR TITLE
Added Github Alerts

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -386,5 +386,30 @@
         "prefix": "sup",
         "body": ["${1}<sup>${0}"],
         "description": "Create a superscript."
+    },
+    "Insert Note": {
+        "prefix": ["note", "n"],
+        "body": "> [!NOTE]\n> ",
+        "description": "Insert Note"
+    },
+    "Insert Tip": {
+        "prefix": ["tip", "t"],
+        "body": "> [!TIP]\n> ",
+        "description": "Insert Tip"
+    },
+    "Insert Important": {
+        "prefix": ["important", "imp"],
+        "body": "> [!IMPORTANT]\n> ",
+        "description": "Insert Important"
+    },
+    "Insert Warning": {
+        "prefix": ["warning", "w"],
+        "body": "> [!WARNING]\n> ",
+        "description": "Insert Warning"
+    },
+    "Insert Caution": {
+        "prefix": ["caution", "c"],
+        "body": "> [!CAUTION]\n> ",
+        "description": "Insert Caution"
     }
 }


### PR DESCRIPTION
Added snippets for Github alerts as in webpages.

For reference, here is the article referring to the feature.  
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

Rendering that will make it look like the picture below, 
<img src="https://docs.github.com/assets/cb-50447/mw-1440/images/help/writing/alerts-rendered.webp">