### PR TITLE
feat(ruby): add `binding.break` snippet

### DIFF
--- a/snippets/ruby/ruby.json
+++ b/snippets/ruby/ruby.json
@@ -240,6 +240,10 @@
         "prefix": "irb",
         "body": "binding.irb"
     },
+    "Insert break call": {
+        "prefix": "break",
+        "body": "binding.break"
+    },
     "Insert RSpec.describe class": {
         "prefix": "rdesc",
         "body": ["RSpec.describe ${1:described_class} do", "\t$0", "end"]


### PR DESCRIPTION
Ruby's official debugger [debug](https://github.com/ruby/debug) comes with a `binding.break` method which is similar to `binding.irb` and `binding.pry` ([see](https://github.com/ruby/debug?tab=readme-ov-file#modify-source-code-with-bindingbreak-similar-to-bindingpry-or-bindingirb)). We already have snippets for `binding.irb` and `binding.pry` but we are missing one for `binding.break`.
