### PR TITLE
Remove some none

### DIFF
--- a/snippets/rust/rust.json
+++ b/snippets/rust/rust.json
@@ -352,10 +352,7 @@
     "match": {
         "prefix": "match",
         "body": [
-            "match ${1:expr} {",
-            "    ${2:Some(expr)} => ${3:expr},",
-            "    ${4:None} => ${5:expr},",
-            "}"
+            "match ${1:expr} {}"
         ],
         "description": "match … { … }"
     },


### PR DESCRIPTION
It doesn't make sense that match defaults to `Some` and `None`...

If you initialize it to `{}` you can use RA code action to `fill in match arms`.