### PR TITLE
fix: correct the formatting of the package.json for some snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,22 +433,22 @@
         	"language": "twig",
                 "path": "./snippets/frameworks/twig.json"
             },
-	    {
-	    	"language": "blade",
-	    	"path": "./snippets/frameworks/blade/blade.json"
-	    },
-	    {
-		"language": "blade",
-		"path": "./snippets/frameworks/blade/helpers.json"
-	    },
-	    {
-		"language": "blade",
-		"path": "./snippets/frameworks/blade/livewire.json"
-	    },
-	    {
-		"language": "blade",
-		"path": "./snippets/frameworks/blade/snippets.json"
-	    },
+            {
+                "language": "blade",
+                "path": "./snippets/frameworks/blade/blade.json"
+            },
+            {
+                "language": "blade",
+                "path": "./snippets/frameworks/blade/helpers.json"
+            },
+            {
+                "language": "blade",
+                "path": "./snippets/frameworks/blade/livewire.json"
+            },
+            {
+                "language": "blade",
+                "path": "./snippets/frameworks/blade/snippets.json"
+            },
             {
                 "language": ["r", "rmd"],
                 "path": "./snippets/r.json"


### PR DESCRIPTION
It appears these issues were never resolved in another PR that I had reviewed (and missed! :frowning_face:), so I'm raising this PR to fix the formatting.