### PR TITLE
jsdoc: fix double parens

### DIFF
--- a/snippets/javascript/jsdoc.json
+++ b/snippets/javascript/jsdoc.json
@@ -434,21 +434,21 @@
     "param": {
         "prefix": "@param",
         "body": [
-            "@param ${{1:type}} ${2:paranName} - ${3:paramDescription}$0"
+            "@param {${1:type}} ${2:paranName} - ${3:paramDescription}$0"
         ],
         "description": "Provides the name, type, and description of a function parameter. Synonysm of @arg and @argument."
     },
     "arg": {
         "prefix": "@arg",
         "body": [
-            "@arg ${{1:type}} ${2:paranName} - ${3:paramDescription}$0"
+            "@arg {${1:type}} ${2:paranName} - ${3:paramDescription}$0"
         ],
         "description": "Provides the name, type, and description of a function parameter. Synonysm of @param and @argument."
     },
     "argument": {
         "prefix": "@argument",
         "body": [
-            "@argument ${{1:type}} ${2:paranName} - ${3:paramDescription}$0"
+            "@argument {${1:type}} ${2:paranName} - ${3:paramDescription}$0"
         ],
         "description": "Provides the name, type, and description of a function parameter. Synonysm of @param and @arg."
     },
@@ -462,7 +462,7 @@
     "property": {
         "prefix": "@property",
         "body": [
-            "@property ${{1:type}} ${2:propertyName.something} - ${3:propertyDescription}$0"
+            "@property {${1:type}} ${2:propertyName.something} - ${3:propertyDescription}$0"
         ],
         "description": "The @property tag is a way to easily document a list of static properties of a class, namespace or other object."
     },
@@ -602,7 +602,7 @@
     "yields": {
         "prefix": "@yields",
         "body": [
-            "@yields ${{1:type}} ${2:description}$0"
+            "@yields {${1:type}} ${2:description}$0"
         ],
         "description": "Document the value yielded by a generator function."
     },


### PR DESCRIPTION
Some jsdoc snippets have double curly brackets, but the dollar sign is in the wrong place.
