### PR TITLE
fix(terraform): remove duplicate resource snippet

### DIFF
--- a/snippets/terraform.json
+++ b/snippets/terraform.json
@@ -141,11 +141,6 @@
     "description": "Outputs are a way to tell Terraform what data is important.",
     "body": ["output \"${myOutput}\" {", "   value = \"\"", "}"]
   },
-  "resource": {
-    "prefix": "tf-resource",
-    "description": "define a provisioner.",
-    "body": ["resource \"${1}\" \"${2}\" {", "\t${3}", "}"]
-  },
   "depends_on": {
     "prefix": "tf-depends_on",
     "description": "Define explicit dependencies.",


### PR DESCRIPTION
Duplicated key `resource` in terraform snippet cause `vsnip` error in my neovim recently.
Probably because this merge request #426 add new resource key but forgot remove the old one. I deleted the old one because two key doing the same purpose but the new one added by #426 is more verbose and good for readability