### PR TITLE
add: quarto snippets for footnotes and citations

### DIFF
--- a/snippets/quarto.json
+++ b/snippets/quarto.json
@@ -131,5 +131,12 @@
             "[@${1:city-key}]"
         ],
         "description": "Insert a citation"
+    },
+    "Insert an inline footnote": {
+        "prefix": "footnote-inline",
+        "body": [
+            "[^${1:note text}]"
+        ],
+        "description": "Insert an inline footnote"
     }
 }

--- a/snippets/quarto.json
+++ b/snippets/quarto.json
@@ -138,5 +138,14 @@
             "[^${1:note text}]"
         ],
         "description": "Insert an inline footnote"
+    },
+    "Insert a footnote": {
+        "prefix": "footnote",
+        "body": [
+            "[^${1:note identifier}]",
+            "[^$1]: ${2:note text}"
+        ],
+        "description": "Insert an inline footnote"
     }
+
 }

--- a/snippets/quarto.json
+++ b/snippets/quarto.json
@@ -146,6 +146,316 @@
             "[^$1]: ${2:note text}"
         ],
         "description": "Insert an inline footnote"
-    }
-
+    },
+  "iframe": {
+    "prefix": ["iframe"],
+    "body": [
+      "::: {#fig-${1:cap}}",
+      "",
+      "${2:paste embed info}",
+      "",
+      "${3:Caption}",
+      ":::"
+    ]
+  },
+  "tabset": {
+    "prefix": ["tabset"],
+    "body": [
+      ":::: {.panel-tabset}",
+      "",
+      "### $1",
+      "",
+      "$2",
+      "",
+      "### $3",
+      "",
+      "$4",
+      "",
+      "::::"
+    ]
+  },
+  "fig3": {
+    "prefix": ["fig3"],
+    "body": [
+      ":::: {#fig-${1:label} layout=\"[[1, 1], [1]]\"}",
+      "",
+      "![${2:subcap1}](${3:figure}){#fig-$2}",
+      "",
+      "![${4:subcap1}](${5:figure}){#fig-$4}",
+      "",
+      "![${6:subcap1}](${7:figure}){#fig-$6}",
+      "",
+      "${8:caption}",
+      "::::"
+    ]
+  },
+  "fig2": {
+    "prefix": ["fig2"],
+    "body": [
+      ":::: {#fig-${1:label} layout=\"[1,1]\"}",
+      "",
+      "![${2:subcap1}](${3:figure}){#fig-$2}",
+      "",
+      "![${4:subcap1}](${5:figure}){#fig-$4}",
+      "",
+      "${6:caption}",
+      "::::"
+    ]
+  },
+  "pycode": {
+    "prefix": ["pyc"],
+    "body": ["```{python} ", "$1", "```"]
+  },
+  "rcode": {
+    "prefix": ["rco"],
+    "body": ["```{r} ", "$1", "```"]
+  },
+  "bashcode": {
+    "prefix": ["bco"],
+    "body": ["```{bash} ", "$1", "```"]
+  },
+  "code": {
+    "prefix": ["code"],
+    "body": ["```{$1} ", "$2", "```", "$0"]
+  },
+  "pyfig2": {
+    "prefix": ["pyfig2"],
+    "body": [
+      "```{python} ",
+      "#| label: fig-$1",
+      "#| fig-cap: \"$2\"",
+      "#| fig-subcap: ",
+      "#|    - \"$3\"",
+      "#|    - \"$4\"",
+      "#| layout-ncol: 2",
+      "",
+      "import numpy as np",
+      "import matplotlib.pyplot as plt",
+      "plt.style.use(['science', 'ieee'])",
+      "$5",
+      "plt.legend()",
+      "plt.show()",
+      "",
+      "$6",
+      "plt.legend()",
+      "plt.show()",
+      "```"
+    ]
+  },
+  "pyfig1": {
+    "prefix": ["pyfig1"],
+    "body": [
+      "```{python}",
+      "#| label: fig-$1",
+      "#| fig-cap: \"$2\"",
+      "",
+      "import numpy as np",
+      "import matplotlib.pyplot as plt",
+      "",
+      "plt.style.use(['science', 'ieee'])",
+      "$3",
+      "plt.show()",
+      "```"
+    ]
+  },
+  "div": {
+    "prefix": ["div"],
+    "body": ["::: {$1}", "$0", ":::"]
+  },
+  "figref": {
+    "prefix": ["figref"],
+    "body": ["@fig-$1"]
+  },
+  "tblref": {
+    "prefix": ["tblref"],
+    "body": ["@tbl-$1"]
+  },
+  "eqnref": {
+    "prefix": ["eqnref"],
+    "body": ["@eq-$1"]
+  },
+  "secref": {
+    "prefix": ["secref"],
+    "body": ["@sec-$1"]
+  },
+  "crossref": {
+    "prefix": ["crossref"],
+    "body": [
+      "crossref:",
+      "  fig-title: Figure",
+      "  tbl-title: Table",
+      "  title-delim: .",
+      "  fig-prefix: Figure",
+      "  tbl-prefix: Table",
+      "  eq-prefix: Eq."
+    ]
+  },
+  "fig": {
+    "prefix": ["fig"],
+    "body": ["![${1:cap1}](${2:figure}){#fig-$3}"]
+  },
+  "background image": {
+    "prefix": ["bgimg"],
+    "body": [
+      "{data-background-image=\"$1\" background-position=center background-size=contain}"
+    ]
+  },
+  "background video": {
+    "prefix": ["bgvid"],
+    "body": [
+      "{background-video=\"$1\" background-size=contain}"
+    ]
+  },
+  "background iframe": {
+    "prefix": ["bgiframe"],
+    "body": [
+      "{background-iframe=\"$1\" background-interactive=true}"
+    ]
+  },
+  "background color": {
+    "prefix": ["bgcol"],
+    "body": [
+      "{background-color=\"$1\"}"
+    ]
+  },
+  "autoanimate": {
+    "prefix": ["anim"],
+    "body": [
+      "{auto-animate=true}"
+    ]
+  },
+  "pl": {
+    "prefix": ["pl"],
+    "body": ["::: {.pull-left}", "$0", ":::"]
+  },
+  "pr": {
+    "prefix": ["pr"],
+    "body": ["::: {.pull-right}", "$0", ":::"]
+  },
+  "container": {
+    "prefix": ["con"],
+    "body": ["::: {.container}", "$1", ":::"]
+  },
+  "incremental": {
+    "prefix": ["inc"],
+    "body": ["::: {.incremental}", "-$1", ":::"]
+  },
+  "nonincremental": {
+    "prefix": ["noninc"],
+    "body": ["::: {.nonincremental}", "-$1", ":::"]
+  },
+  "pause": {
+    "prefix": ["pause"],
+    "body": [". . ."]
+  },
+  "2col": {
+    "prefix": ["2col"],
+    "body": [
+      "::: {.columns}",
+      "::: {.column width=50%}",
+      "$1",
+      ":::",
+      "::: {.column width=50%}",
+      "$2",
+      ":::",
+      ":::"
+    ]
+  },
+  "cols": {
+    "prefix": ["cols"],
+    "body": [
+      "::: {.columns}",
+      "::: {.column width=\"$1\"}",
+      "$2",
+      ":::",
+      "::: {.column width=\"$3\"}",
+      "$4",
+      ":::",
+      ":::"
+    ]
+  },
+  "lay": {
+    "prefix": ["lay"],
+    "body": ["::: {layout=\"[$1]\"}", "$0", ":::"]
+  },
+  "layout-valign": {
+    "prefix": ["valign"],
+    "body": ["layout-valign=\"$0\""]
+  },
+  "callout": {
+    "prefix": ["call"],
+    "body": ["::: {.callout-$1}", "$0", ":::"]
+  },
+  "col2": {
+    "prefix": ["col2"],
+    "body": ["::: {layout-ncol=2}", "$0", ":::"]
+  },
+  "col3": {
+    "prefix": ["col3"],
+    "body": ["::: {layout-ncol=3}", "$0", ":::"]
+  },
+  "absolute": {
+    "prefix": ["absolute"],
+    "body": ["{.absolute top=$1 left=$2 width=\"$3\" height=\"$4\"}"]
+  },
+  "width": {
+    "prefix": ["width"],
+    "body": ["{width=\"$3\"}"]
+  },
+  "hidden": {
+    "prefix": ["hidden"],
+    "body": ["{visibility=\"hidden\"}"]
+  },
+  "uncount": {
+    "prefix": ["uncount"],
+    "body": ["{visibility=\"uncounted\"}"]
+  },
+  "align": {
+    "prefix": ["align"],
+    "body": ["{fig-align=\"center\"}"]
+  },
+  "fragment": {
+    "prefix": ["frag"],
+    "body": ["::: {.fragment}", "$0", ":::"]
+  },
+  "notes": {
+    "prefix": ["notes"],
+    "body": ["::: {.notes}", "$0", ":::"]
+  },
+  "aside": {
+    "prefix": ["aside"],
+    "body": ["::: {.aside}", "$0", ":::"]
+  },
+  "alert": {
+    "prefix": ["alert"],
+    "body": ["[$0]{.alert}"]
+  },
+  "importmarkdown": {
+    "prefix": ["importmd"],
+    "body": ["from IPython.display import display, Markdown"]
+  },
+  "pymarkdown": {
+    "prefix": ["pymd"],
+    "body": ["display(Markdown(\"\"\"", "{$1}", "\"\"\".format($1 = $1)))", ""]
+  },
+  "bibliography": {
+    "body": "bibliography: references.bib",
+    "description": "add bibliography yaml",
+    "prefix": "bib"
+  },
+  "diary header": {
+    "body": ["---", "title: \"$1\"", "date: \"$2\"", "categories: [$3]", "---"],
+    "description": "Add minimal yaml header",
+    "prefix": "diary"
+  },
+  "yaml header": {
+    "body": ["---", "title: $1", "format: $2", "---"],
+    "description": "Add minimal yaml header",
+    "prefix": "yml"
+  },
+  "ref a wrap figure": {
+    "body": "Fig. \\ref{fig-$1}",
+    "description": "refer to a label for a wrap figure",
+    "prefix": "@wrap"
+  }
 }

--- a/snippets/quarto.json
+++ b/snippets/quarto.json
@@ -124,5 +124,12 @@
             ":::"
         ],
         "description": "Insert callout block"
+    },
+    "Insert citation": {
+        "prefix": "cite",
+        "body": [
+            "[@${1:city-key}]"
+        ],
+        "description": "Insert a citation"
     }
 }


### PR DESCRIPTION
Footnotes are done in pandoc-style, e.g.
```markdown
this is a footnote [^identifier]
[^identifier]: with its description here
```
The identifier must be identical, hence the duplicated tabstop.