### PR TITLE
feat(gitcommit): add common git commit trailers

### DIFF
--- a/snippets/gitcommit.json
+++ b/snippets/gitcommit.json
@@ -46,5 +46,17 @@
     "breaking change conventional commit footer": {
         "prefix": "BREAK",
         "body": ["BREAKING CHANGE: $0"]
+    },
+    "co-authored by": {
+        "prefix": "co",
+        "body": ["Co-authored-by: ${1:name} <${2:email}>", "$0"]
+    },
+    "signed off by": {
+        "prefix": "si",
+        "body": ["Signed-off-by: ${1:name} <${2:email}>", "$0"]
+    },
+    "on behalf of": {
+        "prefix": "on",
+        "body": ["On-behalf-of: ${1:org} <${2:email}>", "$0"]
     }
 }


### PR DESCRIPTION
Co-authored-by and Signed-off-by are mentioned in [1].

On-behalf-of is from [2].

[1] https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---trailerlttokengtltvaluegt
[2] https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-on-behalf-of-an-organization
