### PR TITLE
fix(pydoc): change prefixes from `"` to `#`

### DIFF
--- a/snippets/python/pydoc.json
+++ b/snippets/python/pydoc.json
@@ -1,6 +1,6 @@
 {
     "comment": {
-        "prefix": "\"\"\"",
+        "prefix": "###",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -21,7 +21,7 @@
         "description": "A Python docstring for functions and methods, including short summary, details, args, returns, and examples. This docstring is an synonym of \"\"\"function."
     },
     "comment simple": {
-        "prefix": "\"\"",
+        "prefix": "##",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -32,7 +32,7 @@
         "description": "A simple Python docstring comment. Useful when you prefer to add the docstrings manually on functions."
     },    
     "module docstring": {
-        "prefix": "\"\"\"module",
+        "prefix": "###module",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -47,7 +47,7 @@
         "description": "A Python docstring for modules, including a one-line summary, details, and example."
     },
     "test module docstring": {
-        "prefix": "\"\"\"test",
+        "prefix": "###test",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -58,7 +58,7 @@
         "description": "Module-level docstrings for test files are not required. They should be included only when there is additional information that can be provided.\n\nExamples include some specifics on how the test should be run, an explanation of an unusual setup pattern, dependency on the external environment, and so on. Docstrings that do not provide any new information should not be used, such as \"\"\"Tests for foo.bar.\"\"\""
     },
     "function docstring": {
-        "prefix": "\"\"\"function",
+        "prefix": "###function",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -79,7 +79,7 @@
         "description": "A Python docstring for functions and methods, including short summary, details, args, returns, and example."
     },
     "function docstring typed": {
-        "prefix": "\"\"\"function_typed",
+        "prefix": "###function_typed",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -100,7 +100,7 @@
         "description": "Alternative Python docstring for functions and methods, with a different type syntax. Some teams prefer it."
     },
     "generator docstring": {
-        "prefix": "\"\"\"generator",
+        "prefix": "###generator",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -121,7 +121,7 @@
         "description": "A Python docstring for generator methods, including a one-line summary, details, parameters, yields, and example. It is the same, but it has yields instead of returns."
     },
     "class docstring": {
-        "prefix": "\"\"\"class",
+        "prefix": "###class",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -135,7 +135,7 @@
         "description": "A Python docstring for classes, including a one-line summary, details, attributes, and returns."
     },
     "exception docstring": {
-        "prefix": "\"\"\"exception",
+        "prefix": "###exception",
         "body": [
             "\"\"\"",
             "${1:A one-line summary.}",
@@ -149,7 +149,7 @@
         "description": "A Python docstring for exceptions, including a one-line summary, description, and attributes."
     },
     "raises docstring": {
-        "prefix": "\n\n\nraises",
+        "prefix": "###raises",
         "body": [
             "Raises:",
             "    ${1:ErrorName}: ${2:Error description.}$0"


### PR DESCRIPTION
`"` prefixes cause problems due to autopairs plugins, there're excessive trailing `"` after the inserted snippet.

I changed them to `#` from rdoc.