### PR TITLE
Update R/`shinymod` snippet

### DIFF
--- a/snippets/r.json
+++ b/snippets/r.json
@@ -127,7 +127,7 @@
             "",
             "${1:name}Server <- function(id) {",
             "  moduleServer(id, function(input, output, session) {",
-            "    ${3}"
+            "    ${3}",
             "  })",
             "}\n"
         ]

--- a/snippets/r.json
+++ b/snippets/r.json
@@ -118,15 +118,17 @@
     "shinymod": {
         "prefix": "shinymod",
         "body": [
-            "${1:name}_UI <- function(id) {",
+            "${1:name}UI <- function(id) {",
             "  ns <- NS(id)",
             "  tagList(",
-            "    ${0}",
+            "    ${2}",
             "  )",
             "}",
             "",
-            "${1:name} <- function(input, output, session) {",
-            "  ",
+            "${1:name}Server <- function(id) {",
+            "  moduleServer(id, function(input, output, session) {",
+            "    ${3}"
+            "  })",
             "}\n"
         ]
     }


### PR DESCRIPTION
The previously used module syntax has been deprecated since 2020, see [Mastering Shiny](https://mastering-shiny.org/scaling-modules.html#updated-app) for details.

Thanks!