### PR TITLE
feat(rust/async-dyn-dispatch): Snippets for async Rust functions and Box<dyn T>

### DIFF
--- a/snippets/rust/rust.json
+++ b/snippets/rust/rust.json
@@ -397,5 +397,30 @@
         "prefix": "while",
         "body": ["while ${1:condition} {", "    ${2:todo!();}", "}"],
         "description": "while … { … }"
+    },
+    "apfn": {
+        "prefix": "pafn",
+        "body": [
+            "pub async fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {",
+            "    ${5:todo!();}",
+            "}"
+        ],
+        "description": "pub async fn …(…) { … }"
+    },
+    "afn": {
+        "prefix": "afn",
+        "body": [
+            "async fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {",
+            "    ${5:todo!();}",
+            "}"
+        ],
+        "description": "async fn …(…) { … }"
+    },
+    "box-dyn": {
+        "prefix": "box-dyn",
+        "body": [
+            "Box<dyn ${1:Name}>"
+        ],
+        "description": "Box<dyn …>"
     }
 }


### PR DESCRIPTION
I've been using these snippets locally for a while, maybe they are friendly enough to be added to the repo as other people working with async Rust could find them useful.