### PR TITLE
change kubernetes cronjob api version to v1

### DIFF
--- a/snippets/kubernetes.json
+++ b/snippets/kubernetes.json
@@ -280,7 +280,7 @@
         "description": "k8s CronJob",
         "body": [
             "# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/",
-            "apiVersion: batch/v1beta1",
+            "apiVersion: batch/v1",
             "kind: CronJob",
             "metadata:",
             "  name: ${1:cronjobname}",


### PR DESCRIPTION
The Kubernetes 1.21 promotes CronJobs to batch/v1