### PR TITLE
fix(latex): Fix excess spacing of `begin` snippet

### DIFF
--- a/snippets/latex/latex-snippets.json
+++ b/snippets/latex/latex-snippets.json
@@ -270,7 +270,7 @@
         "prefix": "begin",
         "body": [
             "\\\\begin{${1:env}}",
-            "\t${1/(enumerate|itemize|list)|(description)|(.*)/${1:+\\item }${2:+\\item[] }${3:+ }/}$0",
+            "\t${1/(enumerate|itemize|list)|(description)|(.*)/${1:+\\item }${2:+\\item[] }${3:+}/}$0",
             "\\\\end{${1:env}}"
         ],
         "description": "Begin - End"


### PR DESCRIPTION

https://github.com/user-attachments/assets/6f894c76-c90f-4c43-b074-ed3d97551c67

```json
"\\begin{}…\\end{}": {
    "prefix": "begin",
    "body": [
        "\\\\begin{${1:env}}",
        "\t${1/(enumerate|itemize|list)|(description)|(.*)/${1:+\\item }${2:+\\item[] }${3:+ }/}$0",
         ^^ already tab'd here                                            remove this space ^
        "\\\\end{${1:env}}"
    ],
    "description": "Begin - End"
},
```