### PR TITLE
vhdl.json: remove duplicated zeroes snippets

### DIFF
--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -282,16 +282,6 @@
         "description": "Zero Others Array",
         "body": "(others => (others => '1'))"
     },
-    "zeroes": {
-        "prefix": "oth",
-        "description": "Zero Others",
-        "body": "(others => '0')"
-    },
-    "zeroes_arr": {
-        "prefix": "otharr",
-        "description": "Zero Others Array",
-        "body": "(others => (others => '0'))"
-    },
     "integer_range_limitation": {
         "prefix": "intr",
         "description": "Integer (Range Limitation)",


### PR DESCRIPTION
The snippets `zeroes` and `zeroes_arr` appear twice, i.e. `zeroes` is defined in line 265 and line 285. 