### PR TITLE
vhdl: add snippets for conditional assignments, signals, variables, functions, procedures, etc.

### DIFF
--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -206,23 +206,21 @@
         "prefix": "function, pfunc",
         "description": "Pure function declaration",
         "body": [
-            "function ${1:func_name}(${2:parameters})",
+            "function ${1:func_name}(${2:})",
             "\treturn ${3:return_type} is",
-            "\t${4:variables}",
             "begin",
             "\t$0",
-            "end function $1"
+            "end function $1;"
         ]
     },
     "procedure": {
         "prefix": "procedure",
         "description": "Procedure declaration",
         "body": [
-            "procedure ${1:proc_name}(${2:parameters}) is",
-            "\t${3:variables}",
+            "procedure ${1:proc_name}(${2:}) is",
             "begin",
             "\t$0",
-            "end procedure $1"
+            "end procedure $1;"
         ]
     },
     "testbench_process": {

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -352,16 +352,6 @@
         "description": "Zero Others Array",
         "body": "(others => (others => '1'))"
     },
-    "zeroes": {
-        "prefix": "oth",
-        "description": "Zero Others",
-        "body": "(others => '0')"
-    },
-    "zeroes_arr": {
-        "prefix": "otharr",
-        "description": "Zero Others Array",
-        "body": "(others => (others => '0'))"
-    },
     "integer_range_limitation": {
         "prefix": "intr",
         "description": "Integer (Range Limitation)",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -212,7 +212,7 @@
             "\t$0",
             "end function $1"
         ]
-    }
+    },
     "testbench_process": {
         "prefix": "tproc, processt",
         "description": "Testbench Process (No Sensitivity List)",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -104,7 +104,7 @@
         "prefix": "whenelse",
         "description": "When-Else assignment",
         "body": [
-            "${1:dst} <= ${2: true_value} when ${3: condition} else ${4:false_value}"
+            "${1:dst} <= ${2: true_value} when ${3: condition} else ${4:false_value};"
         ]
     },
     "if": {

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -208,9 +208,21 @@
         "body": [
             "function ${1:func_name}(${2:parameters})",
             "\treturn ${3:return_type} is",
+            "\t${4:variables}",
             "begin",
             "\t$0",
             "end function $1"
+        ]
+    },
+    "procedure": {
+        "prefix": "procedure",
+        "description": "Procedure declaration",
+        "body": [
+            "procedure ${1:proc_name}(${2:parameters}) is",
+            "\t${3:variables}",
+            "begin",
+            "\t$0",
+            "end procedure $1"
         ]
     },
     "testbench_process": {

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -80,7 +80,7 @@
         ]
     },
     "case_generate": {
-        "prefix": "case",
+        "prefix": "casegen",
         "description": "Case Generate Statement",
         "body": [
             "${1:generate_label}: case ${2:expression} generate",
@@ -99,7 +99,7 @@
         "body": ["if ${1:condition} then", "\t$0", "end if;"]
     },
     "if_generate": {
-        "prefix": "if",
+        "prefix": "ifgen",
         "description": "If Generate Statement",
         "body": [
             "${1:generate_label}: if ${2:condition} generate",
@@ -124,7 +124,7 @@
         "body": ["for ${1:loop_var} in ${2:range} loop", "\t$0", "end loop;"]
     },
     "for_generate": {
-        "prefix": "for",
+        "prefix": "forgen",
         "description": "For Generate",
         "body": [
             "${1:generate_label}: for ${2:iteration} generate",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -202,6 +202,17 @@
             "constant ${1:const_name} : ${2:integer} := ${3:0};"
         ]
     },
+    "function": {
+        "prefix": "function, pfunc",
+        "description": "Pure function declaration",
+        "body": [
+            "function ${1:func_name}(${2:parameters})",
+            "\treturn ${3:return_type} is",
+            "begin",
+            "\t$0",
+            "end function $1"
+        ]
+    }
     "testbench_process": {
         "prefix": "tproc, processt",
         "description": "Testbench Process (No Sensitivity List)",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -181,6 +181,27 @@
             "signal ${1:signal_name} : ${2:std_logic} := ${3:'0'};"
         ]
     },
+    "variable": {
+        "prefix": "variable",
+        "description": "variable declaration",
+        "body": [
+            "variable ${1:var_name} : ${2:integer};"
+        ]
+    },
+    "variable initialised": {
+        "prefix": "vari, variablei",
+        "description": "Variable declaration with initialisation",
+        "body": [
+            "variable ${1:var_name} : ${2:integer} := ${3:0};"
+        ]
+    },
+    "constant": {
+        "prefix": "constant",
+        "description": "Constant declaration with initialisation",
+        "body": [
+            "constant ${1:const_name} : ${2:integer} := ${3:0};"
+        ]
+    },
     "testbench_process": {
         "prefix": "tproc, processt",
         "description": "Testbench Process (No Sensitivity List)",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -100,6 +100,13 @@
             "with ${1:src} select ${2:dst} <= ${3:value} when $4{condition};"
         ]
     },
+    "when_else": {
+        "prefix": "whenelse",
+        "description": "When-Else assignment",
+        "body": [
+            "${1:dst} <= ${2: true_value} when ${3: condition} else ${4:false_value}"
+        ]
+    },
     "if": {
         "prefix": "if",
         "description": "If Statement",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -93,6 +93,13 @@
             "end generate $1;"
         ]
     },
+    "with_select": {
+        "prefix": "with",
+        "description": "With-Select assignment",
+        "body": [
+            "with ${1:src} select ${2:dst} <= ${3:value} when $4{condition};"
+        ]
+    },
     "if": {
         "prefix": "if",
         "description": "If Statement",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -167,6 +167,20 @@
             "subtype ${1:subtype_name} is ${2:base_type} range ${3:0} ${4|to,downto|} ${5:7};"
         ]
     },
+    "signal": {
+        "prefix": "signal",
+        "description": "Signal declaration",
+        "body": [
+            "signal ${1:signal_name} : ${2:std_logic};"
+        ]
+    },
+    "signal initialised": {
+        "prefix": "sigi, signali",
+        "description": "Signal declaration with initialisation",
+        "body": [
+            "signal ${1:signal_name} : ${2:std_logic} := ${3:'0'};"
+        ]
+    },
     "testbench_process": {
         "prefix": "tproc, processt",
         "description": "Testbench Process (No Sensitivity List)",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -285,7 +285,7 @@
     "std_logic": {
         "prefix": "std",
         "description": "std_logic Type",
-        "body": "std_logic;"
+        "body": "std_logic"
     },
     "std_logic initialised": {
         "prefix": "stdi",
@@ -295,7 +295,7 @@
     "std_logic_vector": {
         "prefix": "stdv",
         "description": "std_logic_vector Type",
-        "body": "std_logic_vector(${1:7} ${2|downto,to|} ${3:0});"
+        "body": "std_logic_vector(${1:7} ${2|downto,to|} ${3:0})"
     },
     "std_logic_vector initialised": {
         "prefix": "stdvi",
@@ -305,7 +305,7 @@
     "std_ulogic_vector": {
         "prefix": "stduv",
         "description": "std_ulogic_vector Type",
-        "body": "std_ulogic_vector(${1:7} ${2|downto,to|} ${3:0});"
+        "body": "std_ulogic_vector(${1:7} ${2|downto,to|} ${3:0})"
     },
     "std_ulogic_vector initialised": {
         "prefix": "stduvi",

--- a/snippets/vhdl.json
+++ b/snippets/vhdl.json
@@ -93,6 +93,11 @@
             "end generate $1;"
         ]
     },
+    "when_in_case": {
+        "prefix": "cwhen, whenc",
+        "description": "when alternative of a case statement",
+        "body": [ "when ${1:choice} => $0" ]
+    },
     "with_select": {
         "prefix": "with",
         "description": "With-Select assignment",


### PR DESCRIPTION
- removes two duplicate snippets
- removes semicolon in the type snippets, like `std_logic`, as this is already inserted in the signal & co snippets
- adds `gen` to the prefixes where there is a generate statement, which makes it easier to differentiate
- adds snippets for essential things like signal, variable, function and procedure declaration