### PR TITLE
ifdef  conditional compilation directive was not working

### DIFF
--- a/snippets/cpp/cpp.json
+++ b/snippets/cpp/cpp.json
@@ -156,7 +156,7 @@
     },
     "#ifdef": {
         "prefix": "#ifdef",
-        "body": ["#ifdef ${1:DEBUG}", "$0", "#endif // ${DEBUG}"],
+        "body": ["#ifdef ${1:DEBUG}", "$0", "#endif // $1"],
         "description": "Code snippet for #ifdef"
     },
     "#ifndef": {


### PR DESCRIPTION
Just changed a single word that had wrong syntax for snippets I suppose. IDK how to describe it. 

Previously:
```cpp
#ifdef POTATO
    std::cout << "Potato\n";
#endif  // DEBUG
````

Now:
```cpp
#ifdef POTATO
    std::cout << "Potato\n";
#endif  // POTATO
````