### PR TITLE
feat(rust): add ifelse snippet

### DIFF
--- a/snippets/rust/rust.json
+++ b/snippets/rust/rust.json
@@ -285,6 +285,17 @@
         "body": ["if ${1:condition} {", "    ${2:todo!();}", "}"],
         "description": "if … { … }"
     },
+    "ifelse": {
+        "prefix": "ifelse",
+        "body": [
+            "if ${1:condition} {",
+            "    ${2:todo!()}",
+            "} else {",
+            "    ${3:todo!()}",
+            "}"
+        ],
+        "description": "if … { … } else { … }"
+    },
     "impl-trait": {
         "prefix": "impl-trait",
         "body": [


### PR DESCRIPTION
This one is not completed by rust-analyzer (or I couldn't triggered it) and is specially useful when used as an expression (like a ternary operator).