### PR TITLE
fix: clean up typos in snippet bodies

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -132,7 +132,7 @@
         "description": "reversed for loop snippet",
         "body": [
             "for ($${1:i} = $${2:array}.Count - 1; $${1:i} -ge 0 ; $${1:i}--) {",
-            "\t${0:${$TM_SELECTED_TEXT}}",
+            "\t${0:${TM_SELECTED_TEXT}}",
             "}"
         ]
     },

--- a/snippets/cobol/vscode_cobol_jcl.json
+++ b/snippets/cobol/vscode_cobol_jcl.json
@@ -51,7 +51,7 @@
             "//SYSUT1   DD *",
             "${3}",
             "/*",
-            "//SYSUT2   DD      DISP=NEW,DSN=${4:A.B.C)",
+            "//SYSUT2   DD      DISP=NEW,DSN=${4:A.B.C}",
             "//SYSPRINT DD      SYSOUT=*",
             "$0"
         ],

--- a/snippets/csharp/csharpdoc.json
+++ b/snippets/csharp/csharpdoc.json
@@ -35,14 +35,14 @@
   "<exception>": {
     "prefix": "<exception>",
     "body": [
-      "<exception cref=\"${1]:ExceptionName}\">${2:description.}$0</exception>"
+      "<exception cref=\"${1:ExceptionName}\">${2:description.}$0</exception>"
     ],
     "description": "This tag provides a way to document the exceptions a method can throw. cref=\"member\" is the name of the exceptionh, which should be a member. The documentation generator checks that the given member exists and translates member to the canonical element name in the documentation file. Description is a description of the circumstances in which the exception is thrown."
   },
   "<include>": {
     "prefix": "<include>",
     "body": [
-      "<include file=\"${1]:filename}\" path=\"${2:xpath}\"/>$0"
+      "<include file=\"${1:filename}\" path=\"${2:xpath}\"/>$0"
     ],
     "description": "This tag allows including information from an XML document that is external to the source code file. The external file must be a well-formed XML document, and an XPath expression is applied to that document to specify what XML from that document to include. The <include> tag is then replaced with the selected XML from the external document. Note this is a self closing tag."
   },

--- a/snippets/fortran.json
+++ b/snippets/fortran.json
@@ -249,7 +249,7 @@
     },
     "max": {
         "prefix": "max",
-        "body": "max($1, $2${, $3:...})$0",
+        "body": "max($1, $2, ${3:...})$0",
         "description": "max",
         "scope": "source.fortran"
     },
@@ -267,7 +267,7 @@
     },
     "min": {
         "prefix": "min",
-        "body": "min($1, $2${, $3:...})$0",
+        "body": "min($1, $2, ${3:...})$0",
         "description": "min",
         "scope": "source.fortran"
     },

--- a/snippets/gdscript.json
+++ b/snippets/gdscript.json
@@ -120,7 +120,7 @@
 
     "element in array": {
         "prefix": "in",
-        "body": ["${1:element} in ${$2:array}"]
+        "body": ["${1:element} in ${2:array}"]
     },
 
     "GDScript template": {

--- a/snippets/objc.json
+++ b/snippets/objc.json
@@ -282,7 +282,7 @@
     },
     "Block field": {
         "prefix": "fieldblock",
-        "body": [":(${1:void} (^${2:nullability}) (${3:parameters}))${4:name)"],
+        "body": [":(${1:void} (^${2:nullability}) (${3:parameters}))${4:name}"],
         "description": "Create a block field"
     },
     "Block typedef": {


### PR DESCRIPTION
This PR fixes several languages which (mostly) had typos in snippet `body`. They all resulted in the snippet not having proper syntax.