### PR TITLE
console.log snippet with 'log' prefix like in vscode

### DIFF
--- a/snippets/javascript/javascript.json
+++ b/snippets/javascript/javascript.json
@@ -431,6 +431,10 @@
         "prefix": "cl",
         "body": "console.log(${0})"
     },
+    "console.log with log": {
+        "prefix": "log",
+        "body": "console.log(${0})"
+    },
     "console.log a variable": {
         "prefix": "cv",
         "body": "console.log('${1}:', ${1})"


### PR DESCRIPTION
Type 'log' to get the completion 'console.log()'. This is the default console.log in vscode.