### PR TITLE
ci: pass globs to prettier rather than the shell

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,4 +27,4 @@ jobs:
           commit_message: "CI: format JSON files"
           only_changed: true
           # This part is also where you can pass other options, for example:
-          prettier_options: --tab-width 4 --parser json --write **/*.json
+          prettier_options: --tab-width 4 --parser json --write "**/*.json"


### PR DESCRIPTION
Without quotes, globs are expanded by the shell. If `**/*.json` is expanded by shell, it only contains json files in a subdirectory of the project's root (e.g., `snippets/css.json`). With quotes, `"**/*.json"` is passed as an argument to `prettier`, and now prettier can work as [expected.](https://prettier.io/docs/en/cli.html)