### PR TITLE
fix(php): fix try catch wrong backlash escaping

### DIFF
--- a/snippets/php/php.json
+++ b/snippets/php/php.json
@@ -241,7 +241,7 @@
         "body": [
             "try {",
             "\t${1://code...}",
-            "} catch (${2:\\Throwable} ${3:\\$th}) {",
+            "} catch (${2:\\\\Throwable} ${3:\\$th}) {",
             "\t${4://throw \\$th;}",
             "}"
         ],


### PR DESCRIPTION
Almost all php snippets are broken when we use the built-in `vim.snippet` functionality, some example of this is the following [issue](https://github.com/Saghen/blink.cmp/issues/184) i'm not really sure if the escaping for special characters has been done correctly in `php.json`, but i fixed the try catch one which i noticed had a missing `\\`