### PR TITLE
fix(go): "if err != nil" (`ir~`)

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -116,7 +116,7 @@
     },
     "if err != nil": {
         "prefix": "ir",
-        "body": "if err != nil {\n\t${1:return ${2:nil, }${3:err}}\n}",
+        "body": "if err != nil {\n\treturn ${1:nil}, ${2:err}\n}",
         "description": "Snippet for if err != nil"
     },
     "fmt.Println": {


### PR DESCRIPTION
The snippets in go.json works great, except this one. It causes an error.

https://github.com/user-attachments/assets/2e1638e3-4dbd-4815-af43-3b18b5b65371

