### PR TITLE
feat(rust): added `eprint/ln` snippets for rust

### DIFF
--- a/snippets/rust/rust.json
+++ b/snippets/rust/rust.json
@@ -144,6 +144,16 @@
         "body": ["println!(\"${1}\");"],
         "description": "println!(…);"
     },
+      "eprintln": {
+        "prefix": "eprintln",
+        "body": ["eprintln!(\"${1}\");"],
+        "description": "eprintln!(…);"
+    },
+      "eprint": {
+        "prefix": "eprint",
+        "body": ["eprint!(\"${1}\");"],
+        "description": "eprint!(…);"
+    },
     "stringify": {
         "prefix": "stringify",
         "body": ["stringify!(${1})"],


### PR DESCRIPTION
why to miss `eprint/ln` ??