### PR TITLE
feat(lua): for / function snippets overhaul

### DIFF
--- a/snippets/lua/lua.json
+++ b/snippets/lua/lua.json
@@ -7,17 +7,17 @@
     "return": {
         "prefix": "rt",
         "body": ["return $0"],
-        "description": "return value"
+        "description": "Return value"
     },
     "assigment": {
         "prefix": "ll",
         "body": ["local ${1:varName} = ${0:value}"],
-        "description": "define a variable"
+        "description": "Define a variable"
     },
     "local": {
         "prefix": "l",
         "body": ["local ${0}"],
-        "description": "declare a variable"
+        "description": "Declare a variable"
     },
     "locreq": {
         "prefix": "lreq",
@@ -72,15 +72,32 @@
             "\t${0}",
             "end"
         ],
-        "description": "read file line by line"
+        "description": "Read file line by line"
     },
     "function": {
         "prefix": "fu",
-        "body": ["function ${1:name}($2)", "\t${0}", "end"]
+        "body": ["function$1($2)", "\t${0}", "end"],
+        "description": "Define a function"
     },
-    "inline-function": {
+    "assign-function": {
         "prefix": "f=",
-        "body": ["local ${1:name} = function($2)", "\t${0}", "end"]
+        "body": ["${1:name} = function($2)", "\t${0}", "end"],
+        "description": "Assign a function to a variable"
+    },
+    "local-function": {
+        "prefix": "lfu",
+        "body": ["local function ${1:name}($2)", "\t${0}", "end"],
+        "description": "Define a local function"
+    },
+    "local-assign-function": {
+        "prefix": "lf=",
+        "body": ["local ${1:name} = function($2)", "\t${0}", "end"],
+        "description": "Assign a function to a local variable"
+    },
+    "member-function": {
+        "prefix": "f,",
+        "body": ["${1:name} = function($2)", "\t${0}", "end,"],
+        "description": "Assign a function to a table key"
     },
     "print": {
         "prefix": "p",

--- a/snippets/lua/lua.json
+++ b/snippets/lua/lua.json
@@ -76,7 +76,7 @@
     },
     "function": {
         "prefix": "fu",
-        "body": ["function$1($2)", "\t${0}", "end"],
+        "body": ["function ${1:name}($2)", "\t${0}", "end"],
         "description": "Define a function"
     },
     "assign-function": {
@@ -93,6 +93,11 @@
         "prefix": "lf=",
         "body": ["local ${1:name} = function($2)", "\t${0}", "end"],
         "description": "Assign a function to a local variable"
+    },
+    "anonymous-function": {
+        "prefix": "f)",
+        "body": ["function($1)", "\t${0}", "end"],
+        "description": "Create an anonymous function"
     },
     "member-function": {
         "prefix": "f,",

--- a/snippets/lua/lua.json
+++ b/snippets/lua/lua.json
@@ -44,12 +44,23 @@
     },
     "for": {
         "prefix": "for",
-        "body": ["for ${1:i}=${2:1},${3:10} do", "\t$0", "end"],
-        "description": "for loop range"
+        "body": ["for $1 do", "\t$0", "end"],
+        "description": "for statement"
     },
-    "foreach": {
-        "prefix": "foreach",
-        "body": ["for i, ${1:x} in pairs(${2:table}) do", "\t$0", "end"]
+    "for-numeric": {
+        "prefix": "forn",
+        "body": ["for ${1:i} = ${2:1}, ${3:10} do", "\t$0", "end"],
+        "description": "for numeric range statement"
+    },
+    "for-ipairs": {
+        "prefix": "fori",
+        "body": ["for ${1:i}, ${2:x} in ipairs(${3:t}) do", "\t$0", "end"],
+        "description": "for i, x in ipairs(t)"
+    },
+    "for-pairs": {
+        "prefix": "forp",
+        "body": ["for ${1:k}, ${2:v} in pairs(${3:t}) do", "\t$0", "end"],
+        "description": "for k, v in pairs(t)"
     },
     "forline": {
         "prefix": "forline",


### PR DESCRIPTION
Rewrite and add more snippets for the `for` statements and functions to cover more use cases.

## For statements

### Before

```lua
-- `for`
for i=1,10 do ... end

-- `foreach`
for i, x in pairs(table) do ... end
```

### After

```lua
-- `for`
for ... do ... end

-- `forn` (for-numeric)
for i = 1, 10 do ... end

-- `fori` (for-ipairs)
for i, x in ipairs(t) ... end

-- `forp` (for-pairs)
for k, v in pairs(t) ... end
```

- `for` is now a generic for loop with zero assumption
- Added variants for 3 typical `for` loops: numeric range, array table, dictionary table
- Added spacing in numeric for: from `i=1,10` to `i = 1, 10`
  - The latter seems predominant on most conventions and formatters.

## Functions

### Before

```lua
-- `fu` (function)
function name(args) ... end

-- `f=` (inline-function)
local name = function(args) ... end
```

### After

```lua
-- `fu` (function)
function(args) ... end
--      ^ note: jump target with empty placeholder between `function` and `(`

-- `f=` (assign-function)
name = function(args) ... end

-- `lfu` (local-function)
local function name(args) ... end

-- `lf=` (local-assign-function)
local name = function(args) ... end

-- `f,` (member-function)
-- local tbl = {
       name = function(args) ... end,
--     existing_key_below = 42,
-- }
```

- `*fu` / `*f=` to support both `function name()` and `name = function()` style.
- `fu`: Removed space and `name` placeholder between `function` and `(`
  - This is in case the function is being used as an anonymous function (typically callbacks)
    ```lua
    vim.wait(300, function()
      print("300ms later")
    end)
    ```
  - The jump target itself still exists between `function` and `(`
- Obvious `l*` local variants
- `member-function`: Same as `f=` but with comma at the `end,`.
  If you assign a function to a key using `f=`, syntax highlights will be broken and the LSP complains until you finally insert the `,` after finishing writing the function.

## Misc

Capitalized the descriptions of the snippets.

Not entirely sure about the styling / punctuation convention for the descriptions and names, though.
The `CONTRIBUTING.md` is missing, and I see no consistency in other language snippets I looked up for reference.
Some snippets are named `foo-bar` like here in `lua.json`, some are `Foo bar`, I don't know.
