### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+[*.lua]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org) is an editor agnostic way to configure project-local settings and is supported by many editors and IDEs out of the box.

I've created `.editorconfig` based on the indentations being used in the existing files. Since many people have indentation settings set to 2 spaces for JSON and Lua, having `.editorconfig` in the repository would help them contribute without having to manually tweak their editor settings every time.