### PR TITLE
feat(lua): `lreq` (local require) snippet improvement

### DIFF
--- a/snippets/lua/lua.json
+++ b/snippets/lua/lua.json
@@ -21,7 +21,7 @@
     },
     "locreq": {
         "prefix": "lreq",
-        "body": ["local ${1:var} = require(${2:module})"],
+        "body": ["local ${1:module} = require(\"${2:$1}\")$0"],
         "description": "Require module as a variable"
     },
     "class": {


### PR DESCRIPTION
Use nested placeholder `${2:$1}` to prefill the `require()` module path with the name of the local variable it is being assigned to.

For example, jumping in `local foo| = require("module")` will prefill `require()` with `"foo"`.