### PR TITLE
Update php snippet due to PSR-12

### DIFF
--- a/snippets/php/php.json
+++ b/snippets/php/php.json
@@ -1,13 +1,25 @@
 {
-    "class …": {
-        "prefix": "class",
+    "class full": {
+        "prefix": "classfull",
         "body": [
-            "class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}} {",
+            "class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}}",
+            "{",
             "\t$0",
             "}",
             ""
         ],
-        "description": "Class definition"
+        "description": "Class full definition"
+    },
+    "class ...": {
+        "prefix": "class",
+        "body": [
+            "${1|final readonly ,final ,readonly |}class ${2:ClassName}",
+            "{",
+            "\t$0",
+            "}",
+            ""
+        ],
+        "description": "Class short definition"
     },
     "PHPDoc class …": {
         "prefix": "doc_class",
@@ -15,7 +27,8 @@
             "/**",
             " * ${6:undocumented class}",
             " */",
-            "class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}} {",
+            "class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}}",
+            "{",
             "\t$0",
             "}",
             ""
@@ -25,7 +38,8 @@
     "function __construct": {
         "prefix": "con",
         "body": [
-            "public function __construct(${1: priarg}) {",
+            "public function __construct(${1: priarg})",
+            "{",
             "}"
         ],
         "description": "Create __construct method using the last php syntax."
@@ -40,7 +54,8 @@
     "function __construct (php 7 or lower)": {
         "prefix": "con7",
         "body": [
-            "public function __construct(${1:${2:Type} \\$${3:var}${4: = ${5:null}}}) {",
+            "public function __construct(${1:${2:Type} \\$${3:var}${4: = ${5:null}}})",
+            "{",
             "\t\\$this->${3:var} = \\$${3:var};$0",
             "}"
         ],
@@ -66,7 +81,8 @@
             "${7: * @return ${8:type}}",
             "${9: * @throws ${10:conditon}}",
             " **/",
-            "${11:public }function ${12:FunctionName}(${13:${14:${4:Type} }\\$${5:var}${15: = ${16:null}}}) {",
+            "${11:public }function ${12:FunctionName}(${13:${14:${4:Type} }\\$${5:var}${15: = ${16:null}}})",
+            "{",
             "\t${0:# code...}",
             "}"
         ],
@@ -80,7 +96,8 @@
     "function …": {
         "prefix": "fun",
         "body": [
-            "${1:public }function ${2:FunctionName}(${3:${4:${5:Type} }\\$${6:var}${7: = ${8:null}}}) {",
+            "${1:public }function ${2:FunctionName}(${3:${4:${5:Type} }\\$${6:var}${7: = ${8:null}}}): ${9:void}",
+            "{",
             "\t${0:# code...}",
             "}"
         ],
@@ -174,12 +191,12 @@
         "description": "Foreach loop"
     },
     "$… = array (…)": {
-        "prefix": "array",
+        "prefix": "arrayold",
         "body": "\\$${1:arrayName} = array('$2' => $3${4:,} $0);",
         "description": "Array initializer"
     },
     "$… = […]": {
-        "prefix": "shorray",
+        "prefix": "array",
         "body": "\\$${1:arrayName} = ['$2' => $3${4:,} $0];",
         "description": "Array initializer"
     },


### PR DESCRIPTION
Definition [for classes ](https://www.php-fig.org/psr/psr-12/#41-extends-and-implements)
> The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the next line after the body.

Definition [for methods](https://www.php-fig.org/psr/psr-12/#44-methods-and-functions)
> Method and function names MUST NOT be declared with space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis.