### PR TITLE
feat(erb): add link_to & comment block snippet

### DIFF
--- a/snippets/erb.json
+++ b/snippets/erb.json
@@ -56,9 +56,19 @@
         "body": ["<%= $1 %>"],
         "description": "render block pe"
     },
+    "comment": {
+        "prefix": ["pc"],
+        "body": ["<%# $1 %>"],
+        "description": "erb print comment"
+    },
     "exec": {
         "prefix": ["er", "%"],
         "body": ["<% $1 %>"],
         "description": "erb exec block"
+    },
+    "link_to": {
+        "prefix": ["lt"],
+        "body": ["<%= link_to $1, $2 %>"],
+        "description": "link_to helper"
     }
 }


### PR DESCRIPTION
Hi,

I'd like to propose adding these two additional `ERB` helpers. I also came across this old [ERB snippet repo](https://github.com/matthewrobertson/ERB-Sublime-Snippets). Tho I don't usually use the other snippets, other people might find them useful. So if ever, we can also include them as well. 

Let me know what you think!