### PR TITLE
fix copyright snippet in global.json

### DIFF
--- a/snippets/global.json
+++ b/snippets/global.json
@@ -1,6 +1,6 @@
 {
     "copyright": {
-        "prefix": "c)",
+        "prefix": "copyright",
         "body": [
             "Copyright (c) ${CURRENT_YEAR} ${0:Author}. All Rights Reserved."
         ],


### PR DESCRIPTION
The parenthesis in "c)" cause snippet unselectable by `require("cmp").mapping.select_next_item()` of [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
