### PR TITLE
Fix: haskell's lambda snippet

### DIFF
--- a/snippets/haskell.json
+++ b/snippets/haskell.json
@@ -106,7 +106,7 @@
     },
     "lambda": {
         "prefix": ["\\", "lambda"],
-        "body": ["\\${1:x} -> ${2:undefined}$0"],
+        "body": ["\\\\${1:x} -> ${2:undefined}$0"],
         "description": "lambda function"
     },
     "pragma": {


### PR DESCRIPTION
Fix snippt error in lamda snippet

The previous snippt body won't show the correct snippt because a `$` goes right after the forefront backslashs. Ths snippet engine will take this as escape characters.