### PR TITLE
added semicolons at the end of statements from "puts" to "reallocarray" down the file chronologically

### DIFF
--- a/snippets/c/c.json
+++ b/snippets/c/c.json
@@ -274,67 +274,67 @@
     },
     "puts": {
         "prefix": "puts",
-        "body": ["puts(\"${1:This function doesn't need newline.}\")$0"],
+        "body": ["puts(\"${1:This function doesn't need newline.}\");$0"],
         "description": "puts() snippet"
     },
     "fputs": {
         "prefix": "fputs",
-        "body": ["fputs(\"${2:This is a simpler printf.\\n}\", ${1:stdout})$0"],
+        "body": ["fputs(\"${2:This is a simpler printf.\\n}\", ${1:stdout});$0"],
         "description": "puts() snippet"
     },
     "printf": {
         "prefix": "printf",
-        "body": ["printf(\"${1:%s}\\n\"$2)$0"],
+        "body": ["printf(\"${1:%s}\\n\"$2);$0"],
         "description": "printf() snippet"
     },
     "fprintf": {
         "prefix": "fprintf",
-        "body": ["fprintf(${1:stderr}, \"${2:%s}\\n\"$3)$0"],
+        "body": ["fprintf(${1:stderr}, \"${2:%s}\\n\"$3);$0"],
         "description": "fprintf() snippet"
     },
     "sprintf": {
         "prefix": "sprintf",
-        "body": ["sprintf(${1:buf}, \"${2:%s}\\n\"$3)$0"],
+        "body": ["sprintf(${1:buf}, \"${2:%s}\\n\"$3);$0"],
         "description": "sprintf() snippet"
     },
     "snprintf": {
         "prefix": "snprintf",
-        "body": ["snprintf(${1:buf}, ${2:max}, \"${3:%s}\\n\"$3)$0"],
+        "body": ["snprintf(${1:buf}, ${2:max}, \"${3:%s}\\n\"$3);$0"],
         "description": "snprintf() snippet"
     },
     "scanf": {
         "prefix": "scanf",
-        "body": ["scanf(\"${1:%d}\"$2)$0"],
+        "body": ["scanf(\"${1:%d}\"$2);$0"],
         "description": "scanf() snippet"
     },
     "fscanf": {
         "prefix": "fscanf",
-        "body": ["fscanf(${1:stdin}, \"${2:%d}\"$3)$0"],
+        "body": ["fscanf(${1:stdin}, \"${2:%d}\"$3);$0"],
         "description": "fscanf() snippet"
     },
     "sscanf": {
         "prefix": "sscanf",
-        "body": ["sscanf(${1:buf}, \"${2:%d}\"$3)$0"],
+        "body": ["sscanf(${1:buf}, \"${2:%d}\"$3);$0"],
         "description": "sscanf() snippet"
     },
     "malloc": {
         "prefix": "malloc",
-        "body": ["malloc(sizeof(${1:int[69]})$2)$0"],
+        "body": ["malloc(sizeof(${1:int[69]})$2);$0"],
         "description": "malloc() snippet"
     },
     "calloc": {
         "prefix": "calloc",
-        "body": ["calloc(${1:1}, sizeof(${2:int})$3)$0"],
+        "body": ["calloc(${1:1}, sizeof(${2:int})$3);$0"],
         "description": "calloc() snippet"
     },
     "realloc": {
         "prefix": "realloc",
-        "body": ["realloc(${1:ptr}, sizeof(${2:int[69]})$3)$0"],
+        "body": ["realloc(${1:ptr}, sizeof(${2:int[69]})$3);$0"],
         "description": "realloc() snippet"
     },
     "reallocarray": {
         "prefix": "reallocarray",
-        "body": ["reallocarray(${1:ptr}, ${2:69}, sizeof(${3:int})$4)$0"],
+        "body": ["reallocarray(${1:ptr}, ${2:69}, sizeof(${3:int})$4);$0"],
         "description": "reallocarray() snippet"
     },
     "free": {


### PR DESCRIPTION
I added a semicolon at the end of these snippets in c. I'm using neovim with nvim-cmp and friendly-snippets for my school c projects and I'm loving it. However, it was getting tedious to tabout of every printf statement to add a semicolon. Most of the time, a semicolon will always go after a printf statement. The only case I can think of when it doesn't use a semicolon is when it is part of a macro definition like here.

`#define PRINT_MESSAGE(msg) printf("%s", msg)`

I think the same can be applied to all the other snippets but if you don't agree i can change the PR to at the very least include the printf snippet. Here are the snippets i added semicolons to the end of:
```
    "puts"
    "fputs"
    "printf"
    "fprintf"
    "sprintf"
    "snprintf"
    "scanf"
    "fscanf"
    "sscanf"
    "malloc"
    "calloc"
    "realloc"
    "reallocarray"
```