### PR TITLE
latex: Better avoid chktex warning24 (followup to #359)

### DIFF
--- a/snippets/latex.json
+++ b/snippets/latex.json
@@ -192,12 +192,12 @@
     },
     "figure": {
         "prefix": "BFI",
-        "body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}\\label{${3:<label>}}\n\\end{figure}",
+        "body": "\\begin{figure}[${1:htbp}]\n\t\\centering\n\t${0:${TM_SELECTED_TEXT}}\n\t\\caption{${2:<caption>}}%\n\t\\label{${3:<label>}}\n\\end{figure}",
         "description": "figure"
     },
     "table": {
         "prefix": "BTA",
-        "body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}\\label{${3:<label>}}\n\\end{table}",
+        "body": "\\begin{table}[${1:htbp}]\n\t\\centering\\begin{tabular}{${4:<columns>}}\n\t\t${0:${TM_SELECTED_TEXT}}\n\t\\end{tabular}\n\t\\caption{${2:<caption>}}%\n\t\\label{${3:<label>}}\n\\end{table}",
         "description": "table"
     },
     "tikzpicture": {

--- a/snippets/latex/latex-snippets.json
+++ b/snippets/latex/latex-snippets.json
@@ -107,7 +107,8 @@
             "\t\\floatname{algorithm}{${1:Algorithm}}",
             "\t\\algrenewcommand\\algorithmicrequire{\\textbf{${2:Input: }}}",
             "\t\\algrenewcommand\\algorithmicensure{\\textbf{${3:Output: }}}",
-            "\t\\caption{$4}\\label{alg:$5}",
+            "\t\\caption{$4}%",
+            "\t\\label{alg:$5}",
             "\t\\begin{algorithmic}[1]",
             "\t\t\\Require \\$input\\$",
             "\t\t\\Ensure \\$output\\$",
@@ -282,7 +283,8 @@
             "\t\\begin{center}",
             "\t\t\\includegraphics[width=0.95\\textwidth]{figures/$1}",
             "\t\\end{center}",
-            "\t\\caption{$3}\\label{fig:$4}",
+            "\t\\caption{$3}%",
+            "\t\\label{fig:$4}",
             "\\end{figure}",
             "$0"
         ],
@@ -293,7 +295,8 @@
         "body": [
             "\\begin{figure}",
             "\t\\includegraphics[width=0.45\\textwidth]{figures/$1}",
-            "\t\\caption{$2}\\label{fig:$3}",
+            "\t\\caption{$2}%",
+            "\t\\label{fig:$3}",
             "\\end{figure}",
             "$0"
         ],
@@ -304,7 +307,8 @@
         "body": [
             "\\begin{figure*}",
             "\t\\includegraphics[width=0.45\\textwidth]{figures/$1}",
-            "\t\\caption{$2}\\label{fig:$3}",
+            "\t\\caption{$2}%",
+            "\t\\label{fig:$3}",
             "\\end{figure*}",
             "$0"
         ],
@@ -314,7 +318,8 @@
         "prefix": "table",
         "body": [
             "\\begin{table}",
-            "\t\\caption{$1}\\label{tab:$2}",
+            "\t\\caption{$1}%",
+            "\t\\label{tab:$2}",
             "\t\\begin{center}",
             "\t\t\\begin{tabular}[c]{l|l}",
             "\t\t\t\\hline",
@@ -336,7 +341,8 @@
         "prefix": "table:acm",
         "body": [
             "\\begin{table}",
-            "\t\\caption{$1}\\label{tab:$2}",
+            "\t\\caption{$1}%",
+            "\t\\label{tab:$2}",
             "\t\\begin{tabular}{${3:ccl}}",
             "\t\t\\toprule",
             "\t\t$4",
@@ -354,7 +360,8 @@
         "prefix": "table:acm:*",
         "body": [
             "\\begin{table*}",
-            "\t\\caption{$1}\\label{tab:$2}",
+            "\t\\caption{$1}%",
+            "\t\\label{tab:$2}",
             "\t\\begin{tabular}{${3:ccl}}",
             "\t\t\\toprule",
             "\t\t$4",


### PR DESCRIPTION
Use a `%` at the end of the line instead of not taking a new line - this is much more readable IMO. CC @DimitrisDimitropoulos for a review.