### PR TITLE
fix some python snippet prefixes, add init snippet

### DIFF
--- a/snippets/python/python.json
+++ b/snippets/python/python.json
@@ -10,14 +10,24 @@
         "description": "Ignore specific line diagnostic in pyright (ignore all is unsafe)"
     },
     "Multiline string": {
-        "prefix": "#ss",
+        "prefix": "#s",
         "body": ["\"\"\"$0", "\"\"\""],
-        "description": "Snippet to avoid autopair plugin annoyances when typing multiple \""
+        "description": "Snippet to avoid weird autopair plugin behaviour"
     },
     "One-line multiline string": {
-        "prefix": "#s",
+        "prefix": "#ss",
         "body": "\"\"\"$0\"\"\"",
-        "description": "Snippet to avoid autopair plugin annoyances when typing multiple \""
+        "description": "Snippet to avoid weird autopair plugin behaviour"
+    },
+    "Single-quote multiline string": {
+        "prefix": "#q",
+        "body": ["'''$0", "'''"],
+        "description": "Snippet to avoid weird autopair plugin behaviour"
+    },
+    "One-line single-quote multiline string": {
+        "prefix": "#qq",
+        "body": "'''$0'''",
+        "description": "Snippet to avoid weird autopair plugin behaviour"
     },
     "self": {
         "prefix": "s",

--- a/snippets/python/python.json
+++ b/snippets/python/python.json
@@ -10,12 +10,12 @@
         "description": "Ignore specific line diagnostic in pyright (ignore all is unsafe)"
     },
     "Multiline string": {
-        "prefix": "#",
+        "prefix": "#ss",
         "body": ["\"\"\"$0", "\"\"\""],
         "description": "Snippet to avoid autopair plugin annoyances when typing multiple \""
     },
     "One-line multiline string": {
-        "prefix": "##",
+        "prefix": "#s",
         "body": "\"\"\"$0\"\"\"",
         "description": "Snippet to avoid autopair plugin annoyances when typing multiple \""
     },
@@ -140,13 +140,18 @@
         "description": "Class definition template"
     },
     "Method": {
-        "prefix": "defs",
+        "prefix": "defm",
         "body": ["def ${1:mname}(self$2):", "\t${3:pass}"],
         "description": "Class method definition"
     },
     "Method w/ return type": {
-        "prefix": "defst",
+        "prefix": "defmt",
         "body": ["def ${1:mname}(self$2) -> ${3:None}:", "\t${4:pass}"],
+        "description": "Class method definition"
+    },
+    "Init method": {
+        "prefix": "defi",
+        "body": ["def __init__(self$1):", "\t${2:pass}"],
         "description": "Class method definition"
     },
     "property template": {


### PR DESCRIPTION
Change "#", "##" to "#ss", "#s", so that the cmp plugin puts in higher.
Add __init__ method snippet.