### PR TITLE
Unity: added snippets for `sfield` and `requirecomponent`

### DIFF
--- a/snippets/frameworks/unity.json
+++ b/snippets/frameworks/unity.json
@@ -717,5 +717,19 @@
         "prefix": "interface",
         "description": "Creates a normal interface.",
         "body": ["public interface ${TM_FILENAME_BASE} {", "\t$0", "}"]
+    },
+    "Attribute: SerializeField": {
+        "prefix": "sfield",
+        "body": [
+            "[SerializeField] private $0;"
+        ],
+        "description": "Force Unity to serialize a private field."
+    },
+    "MonoBehaviour RequireComponent": {
+        "prefix": "RequireComponent",
+        "body": [
+            "[RequireComponent(typeof($0))]"
+        ],
+        "description": "Automatically adds required components as dependencies."
     }
 }


### PR DESCRIPTION
Sourced from
https://github.com/kleber-swf/vscode-unity-code-snippets/blob/develop/snippets/snippets.json

These are new snippets that have been added since the last time this repository was used as a source (https://github.com/rafamadriz/friendly-snippets/commit/6ba7ee6ce4371e142fc9d7653020cb468932ec57)

