### PR TITLE
Fixed typo in systemverilog snippet

### DIFF
--- a/snippets/systemverilog.json
+++ b/snippets/systemverilog.json
@@ -630,7 +630,7 @@
     "uvm_shutdown_phase": {
         "prefix": ["uvm_phase_shutdown", "uvm_shutdown_phase"],
         "body": [
-            "virtual task shutdown_phase(uvm_pase phase);",
+            "virtual task shutdown_phase(uvm_phase phase);",
             "\t$1",
             "endtask: shutdown_phase"
         ],


### PR DESCRIPTION
uvm_shutdown_phase had a typo "pase" instead of "pHase"