### PR TITLE
Add elixir snippets to define functions with args

### DIFF
--- a/snippets/elixir.json
+++ b/snippets/elixir.json
@@ -9,15 +9,30 @@
         "body": ["def ${1:name}() do", "  $0", "end"],
         "description": "Define a function"
     },
+    "defa": {
+        "prefix": "defa",
+        "body": ["def ${1:name}(${2:args}) do", "  $0", "end"],
+        "description": "Define a function with arguments"
+    },
     "defp": {
         "prefix": "defp",
         "body": ["defp ${1:name}() do", "  $0", "end"],
         "description": "Define a private function"
     },
+    "defpa": {
+        "prefix": "defpa",
+        "body": ["defp ${1:name}(${2:args}) do", "  $0", "end"],
+        "description": "Define a private function with arguments"
+    },
     "df": {
         "prefix": "df",
         "body": "def ${1:name}(), do: $0",
         "description": "Define a one-liner function"
+    },
+    "dfa": {
+        "prefix": "dfa",
+        "body": "def ${1:name}(${2:args}), do: $0",
+        "description": "Define a one-liner function with arguments"
     },
     "dfw": {
         "prefix": "dfw",


### PR DESCRIPTION
The current snippets for defining functions don't have any tabstops in between the opening and closing parens () of a function definition, so if you want to define a function that has arguments, you won't be able to tab your way into writing them.

The new snippets append an `a` to their respective "inspiration" snippets, to indicate that they'll have a tabstop for easy [a]rguments.