### PR TITLE
Python: async snippets

### DIFF
--- a/snippets/python/python.json
+++ b/snippets/python/python.json
@@ -93,6 +93,16 @@
         "body": ["for ${1:value} in ${2:iterable}:", "\t${3:pass}"],
         "description": "for loop"
     },
+    "async for": {
+        "prefix": "afor",
+        "body": ["async for ${1:item} in ${2:aiterable}:", "\t${3:pass}"],
+        "description": "Async for loop"
+    },
+    "async generator": {
+        "prefix": "agen",
+        "body": ["async def ${1:gen_name}($2):", "\t${3:yield $4}"],
+        "description": "Async generator function"
+    },
     "for w/ range": {
         "prefix": "forr",
         "body": ["for ${1:value} in range($2):", "\t${3:pass}"],
@@ -102,6 +112,11 @@
         "prefix": "with",
         "body": ["with ${1:expression} as ${2:target}:", "\t${3:pass}"],
         "description": "'with' statement"
+    },
+    "async with": {
+        "prefix": "awith",
+        "body": ["async with ${1:expression} as ${2:var}:", "\t${3:pass}"],
+        "description": "Async context manager"
     },
     "lambda": {
         "prefix": "lambda",
@@ -117,6 +132,16 @@
         "prefix": "deft",
         "body": ["def ${1:fname}($2) -> ${3:None}:", "\t${4:pass}"],
         "description": "Function definition with return type"
+    },
+    "Async Function": {
+        "prefix": "adef",
+        "body": ["async def ${1:fname}($2):", "\t${3:pass}"],
+        "description": "Async function definition"
+    },
+    "Async Function w/ return type": {
+        "prefix": "adeft",
+        "body": ["async def ${1:fname}($2) -> ${3:None}:", "\t${4:pass}"],
+        "description": "Async function definition with return type"
     },
     "class": {
         "prefix": "class",
@@ -148,6 +173,16 @@
         "prefix": "defst",
         "body": ["def ${1:mname}(self$2) -> ${3:None}:", "\t${4:pass}"],
         "description": "Class method definition"
+    },
+    "Async method": {
+        "prefix": "adefs",
+        "body": ["async def ${1:mname}(self$2):", "\t${3:pass}"],
+        "description": "Async class method definition"
+    },
+    "Async method w/ return type": {
+        "prefix": "adefst",
+        "body": ["async def ${1:mname}(self$2) -> ${3:None}:", "\t${4:pass}"],
+        "description": "Async class method definition"
     },
     "property template": {
         "prefix": "property",


### PR DESCRIPTION
Adding some async python snippets to the defaults. Convention is to prefix the same snippets with `a`.