### PR TITLE
Move jsdoc comment snippets

### DIFF
--- a/snippets/javascript/javascript.json
+++ b/snippets/javascript/javascript.json
@@ -937,5 +937,31 @@
         "prefix": "setDate",
         "body": ["setDate($1);", "$0"],
         "description": "The setDate() method changes the day of the month of a given Date instance, based on local time."
+    },
+    "comment": {
+        "prefix": "/**",
+        "body": [
+            "/**",
+            " * ${1:What it does}.",
+            " *",
+            " * @param ${3:name} - ${4:Parameter description.}",
+            " * @returns ${2:Type and description of the returned object.}",
+            " *",
+            " * @example",
+            " * ```",
+            " * ${5:Write me later.}$0",
+            " * ```",
+            " */"
+        ],
+        "description": "A full JSDoc comment with description, parameters, return, and example."
+    },
+    "comment simple": {
+        "prefix": "/*",
+        "body": [
+            "/**",
+            " * ${1:Comment.}$0",
+            " */"
+        ],
+        "description": "A simpple JSDoc comment."
     }
 }

--- a/snippets/javascript/jsdoc.json
+++ b/snippets/javascript/jsdoc.json
@@ -1,30 +1,4 @@
 {
-    "comment": {
-        "prefix": "/**",
-        "body": [
-            "/**",
-            " * ${1:What it does}.",
-            " *",
-            " * @param ${3:name} - ${4:Parameter description.}",
-            " * @returns ${2:Type and description of the returned object.}",
-            " *",
-            " * @example",
-            " * ```",
-            " * ${5:Write me later.}$0",
-            " * ```",
-            " */"
-        ],
-        "description": "A full JSDoc comment with description, parameters, return, and example."
-    },
-    "comment simple": {
-        "prefix": "/*",
-        "body": [
-            "/**",
-            " * ${1:Comment.}$0",
-            " */"
-        ],
-        "description": "A simpple JSDoc comment."
-    },
     "abstract": {
         "prefix": "@abstract",
         "body": [

--- a/snippets/javascript/tsdoc.json
+++ b/snippets/javascript/tsdoc.json
@@ -1,30 +1,4 @@
 {
-    "comment": {
-        "prefix": "/**",
-        "body": [
-            "/**",
-            " * ${1:What it does.}",
-            " *",
-            " * @param ${3:name} - ${4:Parameter description.}",
-            " * @returns ${2:Type and description of the returned object.}",
-            " *",
-            " * @example",
-            " * ```",
-            " * ${5:Write me later.}$0",
-            " * ```",
-            " */"
-        ],
-        "description": "A full TSDoc comment with description, parameters, return, and example."
-    },
-    "comment simple": {
-        "prefix": "/*",
-        "body": [
-            "/**", 
-            " * ${1:Comment.}$0", 
-            " */"
-        ],
-        "description": "A simple TSDoc comment."
-    },
     "alpha": {
         "prefix": "@alpha",
         "body": ["@alpha$0"],

--- a/snippets/javascript/typescript.json
+++ b/snippets/javascript/typescript.json
@@ -216,5 +216,31 @@
         "prefix": "#endregion",
         "body": ["//#endregion"],
         "description": "Folding Region End"
+    },
+    "comment": {
+        "prefix": "/**",
+        "body": [
+            "/**",
+            " * ${1:What it does.}",
+            " *",
+            " * @param ${3:name} - ${4:Parameter description.}",
+            " * @returns ${2:Type and description of the returned object.}",
+            " *",
+            " * @example",
+            " * ```",
+            " * ${5:Write me later.}$0",
+            " * ```",
+            " */"
+        ],
+        "description": "A full TSDoc comment with description, parameters, return, and example."
+    },
+    "comment simple": {
+        "prefix": "/*",
+        "body": [
+            "/**", 
+            " * ${1:Comment.}$0", 
+            " */"
+        ],
+        "description": "A simple TSDoc comment."
     }
 }


### PR DESCRIPTION
Move comment snippets to JavaScript and TypeScript snippets. This is related to issue #600 