### PR TITLE
tsx file (filetype: typescriptreact) should be associated with html

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
                     "pug",
                     "eruby",
                     "javascriptreact",
+                    "typescriptreact",
                     "htmldjango",
                     "astro",
                     "blade"


### PR DESCRIPTION
Problem:
When writing tsx file (filetype: typescriptreact), there is no html tag completion available. I use blink.cmp where friendly-snippets is enabled, but html tag completion works only in jsx file but not tsx file.

Solution:
Linking typescriptreact to html in package.json should fix this.