### PR TITLE
Adds debugging snippet for erb

### DIFF
--- a/snippets/erb.json
+++ b/snippets/erb.json
@@ -70,5 +70,10 @@
         "prefix": ["lt"],
         "body": ["<%= link_to $1, $2 %>"],
         "description": "link_to helper"
+    },
+    "pry": {
+        "prefix": ["pry"],
+        "body": ["<% require 'pry'; binding.pry %>"],
+        "description": "Insert pry debugger"
     }
 }


### PR DESCRIPTION
What

- Adds a debugging snippet for eruby

Why

- I use this all the time and it makes sense to have it added to erb.json permanently