### PR TITLE
feat: opentofu support

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
                 "path": "./snippets/frameworks/remix-ts.json"
             },
             {
-                "language": "terraform",
+                "language": ["terraform", "opentofu"],
                 "path": "./snippets/terraform.json"
             },
             {


### PR DESCRIPTION
[Opentofu](https://opentofu.org/) is a fork of [Terraform](https://developer.hashicorp.com/terraform). 

At the moment the syntax is mostly the same, so using the same snippets for both languages make still sense. When they diverge in the future it might be better to maintain different snippets, but not now.