### PR TITLE
fix: Remove nested placeholder

### DIFF
--- a/snippets/kubernetes.json
+++ b/snippets/kubernetes.json
@@ -448,7 +448,7 @@
             "      terminationGracePeriodSeconds: 10",
             "      containers:",
             "      - name: ${1:myapp}",
-            "        image: ${4:${1:myapp}-slim:1.16.1}",
+            "        image: ${4:debian:latest}",
             "        ports:",
             "        - containerPort: ${5:80}",
             "          name: ${1:myapp}",


### PR DESCRIPTION
Closes https://github.com/rafamadriz/friendly-snippets/issues/612

The snippet for StatefulSet couldn't be inserted by neovim because the grammar isn't supported (yet). This PR sets the placeholder to just `debian:latest`.