### PR TITLE
style(latex): replace $$ with recommended \[ \] for Centered Math snippet

### DIFF
--- a/snippets/latex/vscode-latex-snippets.json
+++ b/snippets/latex/vscode-latex-snippets.json
@@ -44,7 +44,7 @@
   },
   "Inline Math": {
     "prefix": ["mathi", "\\mathi"],
-    "body": ["$${1}$$0"],
+    "body": [" $${1}$ $0"],
     "description": "Insert inline Math Environment."
   },
   "Centered Math": {

--- a/snippets/latex/vscode-latex-snippets.json
+++ b/snippets/latex/vscode-latex-snippets.json
@@ -33,22 +33,22 @@
     "description": "Use the default template which includes a variety of packages and declared-commands. The template will also automatically generate the title and author, as well as date, and will formate the document."
   },
   "Large Summation": {
-    "prefix": ["sumlarge", "\\sumlarge"],
-    "body": ["\\displaystyle\\sum_{$1}^{$2} $3 ${4:,}"],
+    "prefix": ["suml", "\\suml"],
+    "body": ["\\displaystyle\\sum_{$1}^{$2} $3 ${4:,}$0"],
     "description": "Insert a large summation notation."
   },
   "Inline Summation": {
-    "prefix": ["suminline", "\\suminline"],
-    "body": ["\\sum_{$1}^{$2} $3"],
+    "prefix": ["sumi", "\\sumi"],
+    "body": ["\\sum_{$1}^{$2} $3$0"],
     "description": "Insert an inline summation notation, (only in the cases when the environment is inline math environment)."
   },
   "Inline Math": {
-    "prefix": ["mathinline", "\\mathinline"],
-    "body": [" \\( $1 \\) $0"],
+    "prefix": ["mathi", "\\mathi"],
+    "body": ["$${1}$$0"],
     "description": "Insert inline Math Environment."
   },
   "Centered Math": {
-    "prefix": ["mathcentered", "\\mathcentered"],
+    "prefix": ["mathc", "\\mathc"],
     "body": [
       "",
       "\\[",
@@ -148,29 +148,29 @@
     "description": "Insert a proof, whose style is already defined in the template. The serial number is automatically generated according to the section."
   },
   "Large Integral": {
-    "prefix": ["integrallarge", "\\integrallarge"],
-    "body": ["\\displaystyle\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4} ${5:,}"],
+    "prefix": ["intl", "\\intl"],
+    "body": ["\\displaystyle\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4} ${5:,}$0"],
     "description": "Insert large integral notation."
   },
   "Inline Integral": {
-    "prefix": ["integralinline", "\\integralinline"],
-    "body": ["\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4}"],
+    "prefix": ["inti", "\\inti"],
+    "body": ["\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4}$0"],
     "description": "Insert inline integral notation, (only in the cases when the environment is inline math environment)."
   },
   "Inline Fraction": {
-    "prefix": ["fractioninline", "\\fractioninline"],
+    "prefix": ["fraci", "\\fraci"],
     "body": ["\\frac{$1}{$2}$0"],
     "description": [
       "Insert inline fraction notation, (only in the cases when the environment is inline math environment)."
     ]
   },
   "Large Fraction": {
-    "prefix": ["fractionlarge", "\\fractionlarge"],
+    "prefix": ["fracl", "\\fracl"],
     "body": ["\\displaystyle\\frac{$1}{$2}$0"],
     "description": ["Insert large fraction notation"]
   },
   "Create 2D Plot environment": {
-    "prefix": ["plotenvironment2d", "\\plotenvironment2d"],
+    "prefix": ["plotenv2d", "\\plotenv2d"],
     "body": [
       "\\begin{tikzpicture}",
       "  \\begin{axis}[",
@@ -189,7 +189,7 @@
     "description": "Create a 2DPlot Environment of pgfplots. The style declarations are already included in the snippet."
   },
   "Plot 2D Graph": {
-    "prefix": ["plotgraph2d", "\\plotgraph2d"],
+    "prefix": ["pltg2d", "\\pltg2d"],
     "body": [
       "\\addplot [",
       "  domain=${1:-10}:${2:10},",
@@ -203,7 +203,7 @@
     "description": "Plot a 2D Graph in the 2D graph environment, noted that this can also be used in the 3D environment."
   },
   "Plot Circle 2D": {
-    "prefix": ["plotcircle2d", "\\plotcircle2d"],
+    "prefix": ["pltcir2d", "\\pltcir2d"],
     "body": [
       "\\addplot [",
       "  domain=0:2*3.14159265,",
@@ -216,7 +216,7 @@
     "description": "Plot a 2D Circle in the 2D graph environment, noted that this can also be used in the 3D environment."
   },
   "Plot Line 2D": {
-    "prefix": ["plotline2d", "\\plotline2d"],
+    "prefix": ["pltln2d", "\\pltln2d"],
     "body": [
       "\\addplot [",
       "  domain=${4:x1}:${5:x2},",
@@ -229,7 +229,7 @@
     "description": "Plot a 2D Line in the 2D graph environment, noted that this can also be used in the 3D environment."
   },
   "Plot Ellipse 2D": {
-    "prefix": ["plotellipse2d", "\\plotellipse2d"],
+    "prefix": ["pltell2d", "\\pltell2d"],
     "body": [
       "\\addplot [",
       "  domain=0:2*3.14159265,",
@@ -242,10 +242,7 @@
     "description": "Plot a 2D Ellipse in the 2D graph environment, noted that this can also be used in the 3D environment."
   },
   "Plot Quadratic Function 2D by Point": {
-    "prefix": [
-      "plotquadraticfunction2dbypoint",
-      "\\plotquadraticfunction2dbypoint"
-    ],
+    "prefix": ["pltquad2d", "\\pltquad2d"],
     "body": [
       "\\addplot [",
       "  domain=${4:x1}:${5:x2},",
@@ -258,7 +255,7 @@
     "description": "Plot a 2D graph of a quadratic function in the 2D graph environment by the given extrema, noted that this can also be used in the 3D environment."
   },
   "Plot Smooth Curve By Point Set": {
-    "prefix": ["plotsmoothcurvebypointset", "\\plotsmoothcurvebypointset"],
+    "prefix": ["pltsmooth", "\\pltsmooth"],
     "body": [
       "\\addplot+[smooth]",
       "coordinates",
@@ -269,7 +266,7 @@
     "description": "Plot a Smooth Curve by point set (2D)."
   },
   "Create 3D Plot Environment": {
-    "prefix": ["plotenvironment3d", "\\plotenvironment3d"],
+    "prefix": ["plotenv3d", "\\plotenv3d"],
     "body": [
       "\\begin{tikzpicture}",
       "  \\begin{axis}[",
@@ -290,7 +287,7 @@
     "description": "Create a 3DPlot Environment of pgfplots. The style declarations are already included in the snippet."
   },
   "Plot 3D Graph": {
-    "prefix": ["plotgraph3d", "\\plotgraph3d"],
+    "prefix": ["pltg3d", "\\pltg3d"],
     "body": [
       "\\addplot3[",
       "  ${1|surf,mesh|},",
@@ -302,7 +299,7 @@
     "description": "Plot a 3D Graph in the 3D graph environment created."
   },
   "Create Align* Environment in Text": {
-    "prefix": ["aligntext", "\\aligntext"],
+    "prefix": ["align", "\\align"],
     "body": [
       "\\begin{align*}",
       "  $1${2:.}",
@@ -311,7 +308,7 @@
     "description": "Create an align environment when the context is in the text environment."
   },
   "Insert Problem Solving Index": {
-    "prefix": ["problemindex", "\\problemindex"],
+    "prefix": ["pindex", "\\pindex"],
     "body": ["\\noindent\\boldsymbol{$1} $0"],
     "description": "Insert problem solving index format."
   },

--- a/snippets/latex/vscode-latex-snippets.json
+++ b/snippets/latex/vscode-latex-snippets.json
@@ -86,7 +86,11 @@
     },
     "Centered Math": {
         "prefix": ["mathcentered", "\\mathcentered"],
-        "body": ["\\$$ $0 \\$$"],
+        "body": [
+            "\\[",
+            "\t$0",
+            "\\]"
+        ],
         "description": "Insert centered Math Environment."
     },
     "Section": {

--- a/snippets/latex/vscode-latex-snippets.json
+++ b/snippets/latex/vscode-latex-snippets.json
@@ -11,6 +11,7 @@
       "\\usepackage{amsmath,amsfonts,amsbsy,amssymb}",
       "\\usepackage{booktabs}",
       "\\usepackage{siunitx}",
+      "\\usepackage{enumitem}",
       "\\setlist[enumerate]{",
       "  nosep,",
       "  wide,",
@@ -43,15 +44,17 @@
   },
   "Inline Math": {
     "prefix": ["mathinline", "\\mathinline"],
-    "body": ["\\( $1 \\)$0"],
+    "body": [" \\( $1 \\) $0"],
     "description": "Insert inline Math Environment."
   },
   "Centered Math": {
     "prefix": ["mathcentered", "\\mathcentered"],
     "body": [
+      "",
       "\\[",
-      "  $0${1:.}",
-      "\\]"
+      "  ${1:.}",
+      "\\]",
+      "$0"
     ],
     "description": "Insert centered Math Environment."
   },

--- a/snippets/latex/vscode-latex-snippets.json
+++ b/snippets/latex/vscode-latex-snippets.json
@@ -1,350 +1,321 @@
 {
-    "Template": {
-        "prefix": ["template", "\\template"],
-        "body": [
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Define Article %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\documentclass{article}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Using Packages %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\usepackage{geometry}",
-            "\\usepackage{graphicx}",
-            "\\usepackage{amssymb}",
-            "\\usepackage{amsmath}",
-            "\\usepackage{amsthm}",
-            "\\usepackage{empheq}",
-            "\\usepackage{mdframed}",
-            "\\usepackage{booktabs}",
-            "\\usepackage{lipsum}",
-            "\\usepackage{graphicx}",
-            "\\usepackage{color}",
-            "\\usepackage{psfrag}",
-            "\\usepackage{pgfplots}",
-            "\\usepackage{bm}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "${3:% Other Settings}",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%% Page Setting %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\geometry{a4paper}",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%% Define some useful colors %%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\definecolor{ocre}{RGB}{243,102,25}",
-            "\\definecolor{mygray}{RGB}{243,243,244}",
-            "\\definecolor{deepGreen}{RGB}{26,111,0}",
-            "\\definecolor{shallowGreen}{RGB}{235,255,255}",
-            "\\definecolor{deepBlue}{RGB}{61,124,222}",
-            "\\definecolor{shallowBlue}{RGB}{235,249,255}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%% Define an orangebox command %%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\newcommand\\orangebox[1]{\\fcolorbox{ocre}{mygray}{\\hspace{1em}#1\\hspace{1em}}}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%% English Environments %%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\newtheoremstyle{mytheoremstyle}{3pt}{3pt}{\\normalfont}{0cm}{\\rmfamily\\bfseries}{}{1em}{{\\color{black}\\thmname{#1}~\\thmnumber{#2}}\\thmnote{\\,--\\,#3}}",
-            "\\newtheoremstyle{myproblemstyle}{3pt}{3pt}{\\normalfont}{0cm}{\\rmfamily\\bfseries}{}{1em}{{\\color{black}\\thmname{#1}~\\thmnumber{#2}}\\thmnote{\\,--\\,#3}}",
-            "\\theoremstyle{mytheoremstyle}",
-            "\\newmdtheoremenv[linewidth=1pt,backgroundcolor=shallowGreen,linecolor=deepGreen,leftmargin=0pt,innerleftmargin=20pt,innerrightmargin=20pt,]{theorem}{Theorem}[section]",
-            "\\theoremstyle{mytheoremstyle}",
-            "\\newmdtheoremenv[linewidth=1pt,backgroundcolor=shallowBlue,linecolor=deepBlue,leftmargin=0pt,innerleftmargin=20pt,innerrightmargin=20pt,]{definition}{Definition}[section]",
-            "\\theoremstyle{myproblemstyle}",
-            "\\newmdtheoremenv[linecolor=black,leftmargin=0pt,innerleftmargin=10pt,innerrightmargin=10pt,]{problem}{Problem}[section]",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Plotting Settings %%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\usepgfplotslibrary{colorbrewer}",
-            "\\pgfplotsset{width=8cm,compat=1.9}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Title & Author %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "\\title{${1:Title}}",
-            "\\author{${2:Haoyun Qin}}",
-            "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
-            "",
-            "\\begin{document}",
-            "    \\maketitle",
-            "    $0",
-            "\\end{document}"
-        ],
-        "description": "Use the default template which includes a variety of packages and declared-commands. The template will also automatically generate the title and author, as well as date, and will formate the document."
-    },
-    "Large Summation": {
-        "prefix": ["sumlarge", "\\sumlarge"],
-        "body": ["\\displaystyle\\sum_{$1}^{$2}$3"],
-        "description": "Insert a large summation notation."
-    },
-    "Inline Summation": {
-        "prefix": ["suminline", "\\suminline"],
-        "body": ["\\sum_{$1}^{$2}$3"],
-        "description": "Insert an inline summation notation, (only in the cases when the environment is inline math environment)."
-    },
-    "Inline Math": {
-        "prefix": ["mathinline", "\\mathinline"],
-        "body": ["\\$ $1 \\$$0"],
-        "description": "Insert inline Math Environment."
-    },
-    "Centered Math": {
-        "prefix": ["mathcentered", "\\mathcentered"],
-        "body": [
-            "\\[",
-            "\t$0",
-            "\\]"
-        ],
-        "description": "Insert centered Math Environment."
-    },
-    "Section": {
-        "prefix": ["section", "\\section"],
-        "body": ["\\section{$1}$0"],
-        "description": "Insert a new section."
-    },
-    "Subsection": {
-        "prefix": ["subsection", "\\subsection"],
-        "body": ["\\subsection{$1}$0"],
-        "description": "Insert a new subsection."
-    },
-    "Header": {
-        "prefix": ["header", "\\header", "##"],
-        "body": "\\section*{$1}$0",
-        "description": "Insert a section without index."
-    },
-    "Header Small": {
-        "prefix": ["headersmall", "\\headersmall", "###"],
-        "body": "\\subsection*{$1}$0",
-        "description": "Insert a subsection without index."
-    },
-    "Italic Text": {
-        "prefix": ["italic", "\\italic", "*"],
-        "body": "\\textit{$1}$0",
-        "description": "Insert italic text."
-    },
-    "Bold Text": {
-        "prefix": ["bold", "\\bold", "**"],
-        "body": "\\textbf{$1}$0",
-        "description": "Insert bold text."
-    },
-    "Bold Italic Text": {
-        "prefix": ["bolditalic", "\\bolditalic", "***"],
-        "body": "\\textbf{\\textit{$1}}$0",
-        "description": "Insert bold italic text."
-    },
-    "Itemize": {
-        "prefix": ["- ", "\\itemize", "itemize"],
-        "body": ["\\begin{itemize}", "\t\\item $1", "\\end{itemize}$0"]
-    },
-    "Up": {
-        "prefix": ["to", "\\to"],
-        "body": ["^ {$1}$0"],
-        "description": "Superscript notation, as well as the power notation."
-    },
-    "Theorem": {
-        "prefix": ["theorem", "\\theorem"],
-        "body": [
-            "\\begin{theorem}[${1:name of the theorem}]",
-            "\t$0",
-            "\\end{theorem}"
-        ],
-        "description": "Insert a theorem, whose style is already defined in the template. The serial number is automatically generated according to the section."
-    },
-    "Problem": {
-        "prefix": ["problem", "\\problem"],
-        "body": [
-            "\\begin{problem}[${1:name of the problem}]",
-            "\t$0",
-            "\\end{problem}"
-        ],
-        "description": "Insert a problem, whose style is already defined in the template. The serial number is automatically generated according to the section."
-    },
-    "Indent": {
-        "prefix": ["tab", "\\tab"],
-        "body": ["\\indent "],
-        "description": "The equivalent of \"\\t\", also known as \"Tab\""
-    },
-    "Definition": {
-        "prefix": ["definition", "\\definition"],
-        "body": [
-            "\\begin{definition}[${1:name of the definition}]",
-            "\t$0",
-            "\\end{definition}"
-        ],
-        "description": "Insert a definition, whose style is already defined in the template. The serial number is automatically generated according to the section."
-    },
-    "Proof": {
-        "prefix": ["proof", "\\proof"],
-        "body": [
-            "\\begin{proof}[Proof ${1:Other Information}]",
-            "\t$0",
-            "\\end{proof}"
-        ],
-        "description": "Insert a proof, whose style is already defined in the template. The serial number is automatically generated according to the section."
-    },
-    "Large Integral": {
-        "prefix": ["integrallarge", "\\integrallarge"],
-        "body": ["\\displaystyle\\int_{$1}^{$2}$3"],
-        "description": "Insert large integral notation."
-    },
-    "Inline Integral": {
-        "prefix": ["integralinline", "\\integralinline"],
-        "body": ["\\int_{$1}^{$2}$3"],
-        "description": "Insert inline integral notation, (only in the cases when the environment is inline math environment)."
-    },
-    "Inline Fraction": {
-        "prefix": ["fractioninline", "\\fractioninline"],
-        "body": ["\\frac{$1}{$2}$0"],
-        "description": [
-            "Insert inline fraction notation, (only in the cases when the environment is inline math environment)."
-        ]
-    },
-    "Large Fraction": {
-        "prefix": ["fractionlarge", "\\fractionlarge"],
-        "body": ["\\displaystyle\\frac{$1}{$2}$0"],
-        "description": ["Insert large fraction notation"]
-    },
-    "Create 2D Plot environment": {
-        "prefix": ["plotenvironment2d", "\\plotenvironment2d"],
-        "body": [
-            "\\begin{tikzpicture}",
-            "\\begin{axis}[",
-            "legend pos=outer north east,",
-            "title=${1:Example},",
-            "axis lines =${2| box, left, middle, center, right, none|},",
-            "xlabel = \\$x\\$,",
-            "ylabel = \\$y\\$,",
-            "variable = t,",
-            "trig format plots = rad,",
-            "]",
-            "$3",
-            "\\end{axis}",
-            "\\end{tikzpicture}$0"
-        ],
-        "description": "Create a 2DPlot Environment of pgfplots. The style declarations are already included in the snippet."
-    },
-    "Plot 2D Graph": {
-        "prefix": ["plotgraph2d", "\\plotgraph2d"],
-        "body": [
-            "\\addplot [",
-            "\tdomain=${1:-10}:${2:10},",
-            "\tsamples=70,",
-            "\tcolor=${3:blue},",
-            "\t]",
-            "\t{${4:x^2 + 2*x + 1}};",
-            "\\addlegendentry{\\$${5:x^2 + 2x + 1}\\$}",
-            "$0"
-        ],
-        "description": "Plot a 2D Graph in the 2D graph environment, noted that this can also be used in the 3D environment."
-    },
-    "Plot Circle 2D": {
-        "prefix": ["plotcircle2d", "\\plotcircle2d"],
-        "body": [
-            "\\addplot [",
-            "\tdomain=0:2*3.14159265,",
-            "\tsamples=70,",
-            "\tcolor=${4:blue},",
-            "\t]",
-            "\t({${1:r}*cos(t)+${2:a}},{${1:r}*sin(t)+${3:b}});",
-            "\\addlegendentry{\\$(x-${2:a})^2+(y-${3:b})^2=${1:r}^2\\$}$0"
-        ],
-        "description": "Plot a 2D Circle in the 2D graph environment, noted that this can also be used in the 3D environment."
-    },
-    "Plot Line 2D": {
-        "prefix": ["plotline2d", "\\plotline2d"],
-        "body": [
-            "\\addplot [",
-            "\tdomain=${4:x1}:${5:x2},",
-            "\tsamples=70,",
-            "\tcolor=${3:blue},",
-            "\t]",
-            "\t{${1:a}*x+${2:b}};",
-            "\\addlegendentry{\\$ y=${1:a}x+${2:b}\\$}$0"
-        ],
-        "description": "Plot a 2D Line in the 2D graph environment, noted that this can also be used in the 3D environment."
-    },
-    "Plot Ellipse 2D": {
-        "prefix": ["plotellipse2d", "\\plotellipse2d"],
-        "body": [
-            "\\addplot [",
-            "\tdomain=0:2*3.14159265,",
-            "\tsamples=70,",
-            "\tcolor=${5:blue},",
-            "\t]",
-            "\t({${1:a}*cos(t)+${3:x}},{${2:b}*sin(t)+${4:y}});",
-            "\\addlegendentry{\\$\\frac{(x-${3:x})^2}{${1:a}^2}+\\frac{(y-${4:y})^2}{${2:b}^2}=1\\$}$0"
-        ],
-        "description": "Plot a 2D Ellipse in the 2D graph environment, noted that this can also be used in the 3D environment."
-    },
-    "Plot Quadratic Function 2D by Point": {
-        "prefix": [
-            "plotquadraticfunction2dbypoint",
-            "\\plotquadraticfunction2dbypoint"
-        ],
-        "body": [
-            "\\addplot [",
-            "\tdomain=${4:x1}:${5:x2},",
-            "\tsamples=70,",
-            "\tcolor=${6:blue},",
-            "\t]",
-            "\t{${1:a}*(x-${2:m})*(x-${2:m})+${3:b}};",
-            "\\addlegendentry{\\$ y=${1:a}(x-${2:m})^2+${3:b}\\$}$0"
-        ],
-        "description": "Plot a 2D graph of a quadratic function in the 2D graph environment by the given extrema, noted that this can also be used in the 3D environment."
-    },
-    "Plot Smooth Curve By Point Set": {
-        "prefix": ["plotsmoothcurvebypointset", "\\plotsmoothcurvebypointset"],
-        "body": [
-            "\\addplot+[smooth]",
-            "coordinates",
-            "{",
-            "${1:seperate the coordinates with spaces}",
-            "};$0"
-        ],
-        "description": "Plot a Smooth Curve by point set (2D)."
-    },
-    "Create 3D Plot Environment": {
-        "prefix": ["plotenvironment3d", "\\plotenvironment3d"],
-        "body": [
-            "\\begin{tikzpicture}",
-            "\\begin{axis}[",
-            "legend pos=outer north east,",
-            "title=${1:Example},",
-            "axis lines =${2| box, left, middle, center, right, none|},",
-            "colormap/${3|hot,hot2,jet,blackwhite,bluered,cool,greenyellow,redyellow,violet|},",
-            "xlabel = \\$x\\$,",
-            "ylabel = \\$y\\$,",
-            "zlabel = \\$z\\$,",
-            "variable = t,",
-            "trig format plots = rad,",
-            "]",
-            "$4",
-            "\\end{axis}",
-            "\\end{tikzpicture}$0"
-        ],
-        "description": "Create a 3DPlot Environment of pgfplots. The style declarations are already included in the snippet."
-    },
-    "Plot 3D Graph": {
-        "prefix": ["plotgraph3d", "\\plotgraph3d"],
-        "body": [
-            "\\addplot3[",
-            "\t${1|surf,mesh|},",
-            "\tsamples=50,",
-            "]",
-            "{${2:x^2+y^2}};",
-            "\\addlegendentry{\\$${3:x}\\$}$0"
-        ],
-        "description": "Plot a 3D Graph in the 3D graph environment created."
-    },
-    "Create Align* Environment in Text": {
-        "prefix": ["aligntext", "\\aligntext"],
-        "body": ["\\begin{align*}", "\t$1", "\\end{align*}$0"],
-        "description": "Create an align environment when the context is in the text environment."
-    },
-    "Insert Problem Solving Index": {
-        "prefix": ["problemindex", "\\problemindex"],
-        "body": ["\\noindent\\textbf{$1} $0"],
-        "description": "Insert problem solving index format."
-    },
-    "Insert Solution Notation": {
-        "prefix": ["solution", "\\solution"],
-        "body": ["\\textit{ Sol. }"],
-        "description": "Insert italic 'Sol.'"
-    }
+  "Template": {
+    "prefix": ["template", "\\template"],
+    "body": [
+      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Define Article %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
+      "\\documentclass{skytex}",
+      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
+      "",
+      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Using Packages %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
+      "\\usepackage{graphicx}",
+      "\\usepackage{amsmath,amsfonts,amsbsy,amssymb}",
+      "\\usepackage{booktabs}",
+      "\\usepackage{siunitx}",
+      "\\setlist[enumerate]{",
+      "  nosep,",
+      "  wide,",
+      "  labelindent=\\parindent,",
+      "  leftmargin=*",
+      "}",
+      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Title & Author %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
+      "",
+      "\\title{${1:Title}}",
+      "\\author{${2:Author}}",
+      "\\date{\\today}",
+      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%",
+      "",
+      "\\begin{document}",
+      "  \\maketitle",
+      "  $0",
+      "\\end{document}"
+    ],
+    "description": "Use the default template which includes a variety of packages and declared-commands. The template will also automatically generate the title and author, as well as date, and will formate the document."
+  },
+  "Large Summation": {
+    "prefix": ["sumlarge", "\\sumlarge"],
+    "body": ["\\displaystyle\\sum_{$1}^{$2} $3 ${4:,}"],
+    "description": "Insert a large summation notation."
+  },
+  "Inline Summation": {
+    "prefix": ["suminline", "\\suminline"],
+    "body": ["\\sum_{$1}^{$2} $3"],
+    "description": "Insert an inline summation notation, (only in the cases when the environment is inline math environment)."
+  },
+  "Inline Math": {
+    "prefix": ["mathinline", "\\mathinline"],
+    "body": ["\\( $1 \\)$0"],
+    "description": "Insert inline Math Environment."
+  },
+  "Centered Math": {
+    "prefix": ["mathcentered", "\\mathcentered"],
+    "body": [
+      "\\[",
+      "  $0${1:.}",
+      "\\]"
+    ],
+    "description": "Insert centered Math Environment."
+  },
+  "Section": {
+    "prefix": ["section", "\\section"],
+    "body": ["\\section{$1}$0"],
+    "description": "Insert a new section."
+  },
+  "Subsection": {
+    "prefix": ["subsection", "\\subsection"],
+    "body": ["\\subsection{$1}$0"],
+    "description": "Insert a new subsection."
+  },
+  "Header": {
+    "prefix": ["header", "\\header", "##"],
+    "body": "\\section*{$1}$0",
+    "description": "Insert a section without index."
+  },
+  "Header Small": {
+    "prefix": ["headersmall", "\\headersmall", "###"],
+    "body": "\\subsection*{$1}$0",
+    "description": "Insert a subsection without index."
+  },
+  "Italic Text": {
+    "prefix": ["italic", "\\italic", "*"],
+    "body": "\\textit{$1}$0",
+    "description": "Insert italic text."
+  },
+  "Bold Text": {
+    "prefix": ["bold", "\\bold", "**"],
+    "body": "\\boldsymbol{$1}$0",
+    "description": "Insert bold text."
+  },
+  "Bold Italic Text": {
+    "prefix": ["bolditalic", "\\bolditalic", "***"],
+    "body": "\\boldsymbol{\\textit{$1}}$0",
+    "description": "Insert bold italic text."
+  },
+  "Itemize": {
+    "prefix": ["- ", "\\itemize", "itemize"],
+    "body": [
+      "\\begin{itemize}",
+      "  \\item $1",
+      "\\end{itemize}$0"
+    ]
+  },
+  "Up": {
+    "prefix": ["to", "\\to"],
+    "body": ["^{$1}$0"],
+    "description": "Superscript notation, as well as the power notation."
+  },
+  "Theorem": {
+    "prefix": ["theorem", "\\theorem"],
+    "body": [
+      "\\begin{theorem}[${1:name of the theorem}]",
+      "  $0",
+      "\\end{theorem}"
+    ],
+    "description": "Insert a theorem, whose style is already defined in the template. The serial number is automatically generated according to the section."
+  },
+  "Problem": {
+    "prefix": ["problem", "\\problem"],
+    "body": [
+      "\\begin{problem}[${1:name of the problem}]",
+      "  $0",
+      "\\end{problem}"
+    ],
+    "description": "Insert a problem, whose style is already defined in the template. The serial number is automatically generated according to the section."
+  },
+  "Indent": {
+    "prefix": ["tab", "\\tab"],
+    "body": ["\\indent "],
+    "description": "The equivalent of \"\\t\", also known as \"Tab\""
+  },
+  "Definition": {
+    "prefix": ["definition", "\\definition"],
+    "body": [
+      "\\begin{definition}[${1:name of the definition}]",
+      "  $0",
+      "\\end{definition}"
+    ],
+    "description": "Insert a definition, whose style is already defined in the template. The serial number is automatically generated according to the section."
+  },
+  "Proof": {
+    "prefix": ["proof", "\\proof"],
+    "body": [
+      "\\begin{proof}[Proof ${1:Other Information}]",
+      "  $0",
+      "\\end{proof}"
+    ],
+    "description": "Insert a proof, whose style is already defined in the template. The serial number is automatically generated according to the section."
+  },
+  "Large Integral": {
+    "prefix": ["integrallarge", "\\integrallarge"],
+    "body": ["\\displaystyle\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4} ${5:,}"],
+    "description": "Insert large integral notation."
+  },
+  "Inline Integral": {
+    "prefix": ["integralinline", "\\integralinline"],
+    "body": ["\\int_{$1}^{$2} $3 \\, \\mathrm{d}{$4}"],
+    "description": "Insert inline integral notation, (only in the cases when the environment is inline math environment)."
+  },
+  "Inline Fraction": {
+    "prefix": ["fractioninline", "\\fractioninline"],
+    "body": ["\\frac{$1}{$2}$0"],
+    "description": [
+      "Insert inline fraction notation, (only in the cases when the environment is inline math environment)."
+    ]
+  },
+  "Large Fraction": {
+    "prefix": ["fractionlarge", "\\fractionlarge"],
+    "body": ["\\displaystyle\\frac{$1}{$2}$0"],
+    "description": ["Insert large fraction notation"]
+  },
+  "Create 2D Plot environment": {
+    "prefix": ["plotenvironment2d", "\\plotenvironment2d"],
+    "body": [
+      "\\begin{tikzpicture}",
+      "  \\begin{axis}[",
+      "    legend pos=outer north east,",
+      "    title=${1:Example},",
+      "    axis lines =${2| box, left, middle, center, right, none|},",
+      "    xlabel = \\( x \\),",
+      "    ylabel = \\( y \\),",
+      "    variable = t,",
+      "    trig format plots = rad,",
+      "  ]",
+      "    $3",
+      "  \\end{axis}",
+      "\\end{tikzpicture}$0"
+    ],
+    "description": "Create a 2DPlot Environment of pgfplots. The style declarations are already included in the snippet."
+  },
+  "Plot 2D Graph": {
+    "prefix": ["plotgraph2d", "\\plotgraph2d"],
+    "body": [
+      "\\addplot [",
+      "  domain=${1:-10}:${2:10},",
+      "  samples=70,",
+      "  color=${3:blue},",
+      "]",
+      "  {${4:x^2 + 2*x + 1}};",
+      "\\addlegendentry{\\( ${5:x^2 + 2x + 1} \\)}",
+      "$0"
+    ],
+    "description": "Plot a 2D Graph in the 2D graph environment, noted that this can also be used in the 3D environment."
+  },
+  "Plot Circle 2D": {
+    "prefix": ["plotcircle2d", "\\plotcircle2d"],
+    "body": [
+      "\\addplot [",
+      "  domain=0:2*3.14159265,",
+      "  samples=70,",
+      "  color=${4:blue},",
+      "]",
+      "  ({${1:r}*cos(t)+${2:a}},{${1:r}*sin(t)+${3:b}});",
+      "\\addlegendentry{\\( \\left( x-${2:a} \\right)^2 + \\left( y-${3:b} \\right)^2 = ${1:r}^2 \\)}$0"
+    ],
+    "description": "Plot a 2D Circle in the 2D graph environment, noted that this can also be used in the 3D environment."
+  },
+  "Plot Line 2D": {
+    "prefix": ["plotline2d", "\\plotline2d"],
+    "body": [
+      "\\addplot [",
+      "  domain=${4:x1}:${5:x2},",
+      "  samples=70,",
+      "  color=${3:blue},",
+      "]",
+      "  {${1:a}*x+${2:b}};",
+      "\\addlegendentry{\\( y = ${1:a}x + ${2:b} \\)}$0"
+    ],
+    "description": "Plot a 2D Line in the 2D graph environment, noted that this can also be used in the 3D environment."
+  },
+  "Plot Ellipse 2D": {
+    "prefix": ["plotellipse2d", "\\plotellipse2d"],
+    "body": [
+      "\\addplot [",
+      "  domain=0:2*3.14159265,",
+      "  samples=70,",
+      "  color=${5:blue},",
+      "]",
+      "  ({${1:a}*cos(t)+${3:x}},{${2:b}*sin(t)+${4:y}});",
+      "\\addlegendentry{\\( \\frac{\\left( x-${3:x} \\right)^2}{${1:a}^2} + \\frac{\\left( y-${4:y} \\right)^2}{${2:b}^2} = 1 \\)}$0"
+    ],
+    "description": "Plot a 2D Ellipse in the 2D graph environment, noted that this can also be used in the 3D environment."
+  },
+  "Plot Quadratic Function 2D by Point": {
+    "prefix": [
+      "plotquadraticfunction2dbypoint",
+      "\\plotquadraticfunction2dbypoint"
+    ],
+    "body": [
+      "\\addplot [",
+      "  domain=${4:x1}:${5:x2},",
+      "  samples=70,",
+      "  color=${6:blue},",
+      "]",
+      "  {${1:a}*(x-${2:m})*(x-${2:m})+${3:b}};",
+      "\\addlegendentry{\\( y = ${1:a} \\left( x-${2:m} \\right)^2 + ${3:b} \\)}$0"
+    ],
+    "description": "Plot a 2D graph of a quadratic function in the 2D graph environment by the given extrema, noted that this can also be used in the 3D environment."
+  },
+  "Plot Smooth Curve By Point Set": {
+    "prefix": ["plotsmoothcurvebypointset", "\\plotsmoothcurvebypointset"],
+    "body": [
+      "\\addplot+[smooth]",
+      "coordinates",
+      "{",
+      "  ${1:seperate the coordinates with spaces}",
+      "};$0"
+    ],
+    "description": "Plot a Smooth Curve by point set (2D)."
+  },
+  "Create 3D Plot Environment": {
+    "prefix": ["plotenvironment3d", "\\plotenvironment3d"],
+    "body": [
+      "\\begin{tikzpicture}",
+      "  \\begin{axis}[",
+      "    legend pos=outer north east,",
+      "    title=${1:Example},",
+      "    axis lines =${2| box, left, middle, center, right, none|},",
+      "    colormap/${3|hot,hot2,jet,blackwhite,bluered,cool,greenyellow,redyellow,violet|},",
+      "    xlabel = \\( x \\),",
+      "    ylabel = \\( y \\),",
+      "    zlabel = \\( z \\),",
+      "    variable = t,",
+      "    trig format plots = rad,",
+      "  ]",
+      "    $4",
+      "  \\end{axis}",
+      "\\end{tikzpicture}$0"
+    ],
+    "description": "Create a 3DPlot Environment of pgfplots. The style declarations are already included in the snippet."
+  },
+  "Plot 3D Graph": {
+    "prefix": ["plotgraph3d", "\\plotgraph3d"],
+    "body": [
+      "\\addplot3[",
+      "  ${1|surf,mesh|},",
+      "  samples=50,",
+      "]",
+      "  {${2:x^2+y^2}};",
+      "\\addlegendentry{\\( ${3:x} \\)}$0"
+    ],
+    "description": "Plot a 3D Graph in the 3D graph environment created."
+  },
+  "Create Align* Environment in Text": {
+    "prefix": ["aligntext", "\\aligntext"],
+    "body": [
+      "\\begin{align*}",
+      "  $1${2:.}",
+      "\\end{align*}$0"
+    ],
+    "description": "Create an align environment when the context is in the text environment."
+  },
+  "Insert Problem Solving Index": {
+    "prefix": ["problemindex", "\\problemindex"],
+    "body": ["\\noindent\\boldsymbol{$1} $0"],
+    "description": "Insert problem solving index format."
+  },
+  "Insert Solution Notation": {
+    "prefix": ["solution", "\\solution"],
+    "body": ["\\textit{Sol.} "],
+    "description": "Insert italic 'Sol.'"
+  }
 }
+


### PR DESCRIPTION
## Description
This PR updates the `Centered Math` snippet to use `\[ ... \]` instead of `$$...$$`.

## Motivation
In modern LaTeX, using `\[ ... \]` is widely considered a best practice over the plain TeX syntax `$$...$$` for unnumbered displayed equations. The benefits include:
1. **Better Spacing**: `\[ ... \]` handles vertical spacing more consistently.
2. **Error Handling**: It provides better error checking and prevents common alignment issues.
3. **Compatibility**: It integrates more seamlessly with document classes and packages like `amsmath`.

Reference: [StackExchange: Why is \[ ... \] preferable to $$...$$?](https://tex.stackexchange.com/questions/503/why-is-bracket-preferable-to-dollar-dollar)

## Changes
Modified the `Centered Math` snippet body:
- From: `"body": ["\\$$ $0 \\$$"]`
- To: 
  ```json
  "body": [
      "\\[",
      "\t$0",
      "\\]"
  ]