### PR TITLE
fix: fix Java's class snippet

### DIFF
--- a/snippets/java/java.json
+++ b/snippets/java/java.json
@@ -6,7 +6,7 @@
     },
     "class": {
         "prefix": "class",
-        "body": ["public class ${1:TM_FILENAME_BASE} {", "\t$0", "}"],
+        "body": ["public class ${1:${TM_FILENAME_BASE}} {", "\t$0", "}"],
         "description": "Public class"
     },
     "sysout": {


### PR DESCRIPTION
Fixed the issue where TM_FILENAME_BASE was inserted as placeholder text instead of the name of the class.