### PR TITLE
fix: revise HTML snippets

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -1,89 +1,89 @@
 {
     "!": {
-        "prefix": "!",
+        "prefix": ["!", "html5"],
         "body": [
             "<!DOCTYPE html>",
-            "<html lang=\"$1en\">",
+            "<html lang=\"${1:en}\">",
             "<head>",
             "\t<meta charset=\"UTF-8\">",
             "\t<meta name=\"viewport\" content=\"width=${2:device-width}, initial-scale=${3:1.0}\">",
             "\t<title>${5:Document}</title>",
             "</head>",
             "<body>",
-            "\t${6}",
+            "\t${0}",
             "</body>",
             "</html>"
         ],
-        "description": "Defines a template for a html5 document"
+        "description": "Defines a template for an HTML5 document"
     },
     "doctype": {
-        "prefix": "doctype",
-        "body": ["<!DOCTYPE>", "$1"],
+        "prefix": ["!!!", "doctype"],
+        "body": ["<!DOCTYPE>", "$0"],
         "description": "Defines the document type"
     },
     "a": {
         "prefix": "a",
-        "body": "<a href=\"$1\">$2</a>$3",
+        "body": "<a href=\"$1\">$2</a>",
         "description": "Defines a hyperlink"
     },
     "abbr": {
         "prefix": "abbr",
-        "body": "<abbr title=\"$1\">$2</abbr>$3",
+        "body": "<abbr title=\"$1\">$2</abbr>",
         "description": "Defines an abbreviation"
     },
     "address": {
         "prefix": "address",
-        "body": ["<address>", "$1", "</address>"],
+        "body": ["<address>", "\t$0", "</address>"],
         "description": "Defines an address element"
     },
     "area": {
         "prefix": "area",
-        "body": "<area shape=\"$1\" coords=\"$2\" href=\"$3\" alt=\"$4\">$5",
+        "body": "<area shape=\"$1\" coords=\"$2\" href=\"$3\" alt=\"$4\">",
         "description": "Defines an area inside an image map"
     },
     "article": {
         "prefix": "article",
-        "body": ["<article>", "\t$1", "</article>"],
+        "body": ["<article>", "\t$0", "</article>"],
         "description": "Defines an article"
     },
     "aside": {
         "prefix": "aside",
-        "body": ["<aside>", "\t$1", "</aside>$2"],
+        "body": ["<aside>", "\t$0", "</aside>"],
         "description": "Defines content aside from the page content"
     },
     "audio": {
         "prefix": "audio",
-        "body": ["<audio controls>", "\t$1", "</audio>"],
+        "body": ["<audio controls src=\"$1\">", "\t$2", "</audio>"],
         "description": "Defines embedded audio content"
     },
     "b": {
         "prefix": "b",
-        "body": "<b>$1</b>$2",
+        "body": "<b>$1</b>",
         "description": "Defines bold text"
     },
     "base": {
         "prefix": "base",
-        "body": "<base href=\"$1\" target=\"$2\">$3",
+        "body": "<base href=\"$1\" target=\"$2\">",
         "description": "Defines a base URL for all the links in a page"
     },
     "bdi": {
         "prefix": "bdi",
-        "body": "<bdi>$1</bdi>$2",
-        "description": "Used to isolate text that is of unknown directionality"
+        "body": "<bdi>$1</bdi>",
+        "description": "Defines isolated text that is of unknown directionality"
     },
     "bdo": {
         "prefix": "bdo",
-        "body": ["<bdo dir=\"$1\">", "$2", "</bdo>"],
+        "body": "<bdo dir=\"$1\">$2</bdo>",
         "description": "Defines the direction of text display"
     },
     "big": {
         "prefix": "big",
-        "body": "<big>$1</big>$2",
-        "description": "Used to make text bigger [DEPRECATED]"
+        "body": "<big>$1</big>",
+        "description": "Defines bigger text [DEPRECATED]"
     },
     "blockquote": {
         "prefix": "blockquote",
-        "body": ["<blockquote cite=\"$2\">", "\t$1", "</blockquote>"],
+        "body": ["<blockquote cite=\"$1\">", "\t$0", "</blockquote>"],
         "description": "Defines a long quotation"
     },
     "body": {
@@ -94,71 +94,71 @@
     "br": {
         "prefix": "br",
         "body": "<br>",
-        "description": "Inserts a single line break"
+        "description": "Defines a single line break"
     },
     "button": {
         "prefix": "button",
-        "body": "<button type=\"$1\">$2</button>$3",
-        "description": "Defines a push button"
+        "body": "<button type=\"$1\">$2</button>",
+        "description": "Defines a clickable button"
     },
     "canvas": {
         "prefix": "canvas",
-        "body": "<canvas id=\"$1\">$2</canvas>$3",
+        "body": "<canvas width=\"$1\" height=\"$2\" id=\"$3\">$4</canvas>",
         "description": "Defines a container for graphics drawn with JavaScript"
     },
     "caption": {
         "prefix": "caption",
-        "body": "<caption>$1</caption>$2",
+        "body": "<caption>$1</caption>",
         "description": "Defines a table caption"
     },
     "cite": {
         "prefix": "cite",
-        "body": "<cite>$1</cite>$2",
-        "description": "Defines a citation"
+        "body": "<cite>$1</cite>",
+        "description": "Defines the title of a creative work"
     },
     "code": {
         "prefix": "code",
-        "body": "<code>$1</code>$2",
+        "body": "<code>$1</code>",
         "description": "Defines computer code text"
     },
     "col": {
         "prefix": "col",
-        "body": "<col>$2",
-        "description": "Defines attributes for table columns"
+        "body": "<col span=\"$1\">",
+        "description": "Defines properties for one or more table columns"
     },
     "colgroup": {
         "prefix": "colgroup",
-        "body": ["<colgroup>", "\t$1", "</colgroup>"],
+        "body": ["<colgroup>", "\t$0", "</colgroup>"],
         "description": "Defines group of table columns"
     },
     "datalist": {
         "prefix": "datalist",
         "body": ["<datalist>", "\t$1", "</datalist>"],
-        "description": "Defines a dropdown list"
+        "description": "Defines a list of predefined options for an input [Limited support]"
     },
     "dd": {
         "prefix": "dd",
-        "body": "<dd>$1</dd>$2",
+        "body": "<dd>$1</dd>",
         "description": "Defines a definition description"
     },
     "del": {
         "prefix": "del",
-        "body": "<del>$1</del>$2",
+        "body": "<del>$1</del>",
         "description": "Defines deleted text"
     },
     "details": {
         "prefix": "details",
-        "body": ["<details>", "\t$1", "</details>"],
-        "description": "Defines details of an element"
+        "body": ["<details>", "\t$0", "</details>"],
+        "description": "Defines a disclosure widget that shows or hides additional content"
     },
     "dialog": {
         "prefix": "dialog",
-        "body": "<dialog>$1</dialog>$2",
+        "body": ["<dialog>", "\t$1", "</dialog>"],
         "description": "Defines a dialog box or modal window"
     },
     "dfn": {
         "prefix": "dfn",
-        "body": "<dfn>$1</dfn>$2",
+        "body": "<dfn>$1</dfn>",
         "description": "Defines a definition term"
     },
     "div": {
@@ -166,34 +166,49 @@
         "body": ["<div>", "\t$1", "</div>"],
         "description": "Defines a generic block-level container"
     },
+    "div.": {
+        "prefix": "div.",
+        "body": ["<div class=\"$1\">", "\t$2", "</div>"],
+        "description": "Defines a generic block-level container"
+    },
+    "div#": {
+        "prefix": "div#",
+        "body": ["<div id=\"$1\">", "\t$2", "</div>"],
+        "description": "Defines a generic block-level container"
+    },
+    "div.#": {
+        "prefix": "div.#",
+        "body": ["<div class=\"$1\" id=\"$2\">", "\t$3", "</div>"],
+        "description": "Defines a generic block-level container"
+    },
     "dl": {
         "prefix": "dl",
-        "body": ["<dl>", "\t$1", "</dl>"],
+        "body": ["<dl>", "\t$0", "</dl>"],
         "description": "Defines a definition list"
     },
     "dt": {
         "prefix": "dt",
-        "body": "<dt>$1</dt>$2",
+        "body": "<dt>$1</dt>",
         "description": "Defines a definition term"
     },
     "em": {
         "prefix": "em",
-        "body": "<em>$1</em>$2",
+        "body": "<em>$1</em>",
         "description": "Defines emphasized text"
     },
     "embed": {
         "prefix": "embed",
-        "body": "<embed src=\"$1\">$2",
+        "body": "<embed src=\"$1\" width=\"$2\" height=\"$3\">",
         "description": "Defines external interactive content or plugin"
     },
     "fieldset": {
         "prefix": "fieldset",
         "body": ["<fieldset>", "\t$1", "</fieldset>"],
-        "description": "Defines a fieldset"
+        "description": "Defines a group of related form controls"
     },
     "figcaption": {
         "prefix": "figcaption",
-        "body": "<figcaption>$1</figcaption>$2",
+        "body": "<figcaption>$1</figcaption>",
         "description": "Defines a caption for a figure"
     },
     "figure": {
@@ -203,47 +218,47 @@
     },
     "footer": {
         "prefix": "footer",
-        "body": ["<footer>", "\t$1", "</footer>"],
+        "body": ["<footer>", "\t$0", "</footer>"],
         "description": "Defines a footer for a section or page"
     },
     "form": {
         "prefix": "form",
-        "body": ["<form>", "\t$1", "</form>"],
+        "body": ["<form>", "\t$0", "</form>"],
         "description": "Defines a form"
     },
     "h1": {
         "prefix": "h1",
-        "body": "<h1>$1</h1>$2",
-        "description": "Defines header 1"
+        "body": "<h1>$1</h1>",
+        "description": "Defines heading level 1"
     },
     "h2": {
         "prefix": "h2",
-        "body": "<h2>$1</h2>$2",
-        "description": "Defines header 2"
+        "body": "<h2>$1</h2>",
+        "description": "Defines heading level 2"
     },
     "h3": {
         "prefix": "h3",
-        "body": "<h3>$1</h3>$2",
-        "description": "Defines header 3"
+        "body": "<h3>$1</h3>",
+        "description": "Defines heading level 3"
     },
     "h4": {
         "prefix": "h4",
-        "body": "<h4>$1</h4>$2",
-        "description": "Defines header 4"
+        "body": "<h4>$1</h4>",
+        "description": "Defines heading level 4"
     },
     "h5": {
         "prefix": "h5",
-        "body": "<h5>$1</h5>$2",
-        "description": "Defines header 5"
+        "body": "<h5>$1</h5>",
+        "description": "Defines heading level 5"
     },
     "h6": {
         "prefix": "h6",
-        "body": "<h6>$1</h6>$2",
-        "description": "Defines header 6"
+        "body": "<h6>$1</h6>",
+        "description": "Defines heading level 6"
     },
     "head": {
         "prefix": "head",
-        "body": ["<head>", "\t$1", "</head>"],
+        "body": ["<head>", "\t$0", "</head>"],
         "description": "Defines information about the document"
     },
     "header": {
@@ -266,381 +281,323 @@
         "body": ["<html>", "\t$0", "</html>"],
         "description": "Defines an html document"
     },
-    "html5": {
-        "prefix": "html5",
-        "body": [
-            "<!DOCTYPE html>",
-            "<html lang=\"${1:en}\">",
-            "\t<head>",
-            "\t\t<meta charset=\"UTF-8\">",
-            "\t\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
-            "\t\t<title>$2</title>",
-            "\t\t<link href=\"${3:css/style.css}\" rel=\"stylesheet\">",
-            "\t</head>",
-            "\t<body>",
-            "\t$0",
-            "\t</body>",
-            "</html>"
-        ],
-        "description": "Defines a template for a html5 document"
-    },
     "i": {
         "prefix": "i",
-        "body": "<i>$1</i>$2",
-        "description": "Defines italic text"
+        "body": "<i>$1</i>",
+        "description": "Defines text with alternate emphasis"
     },
     "iframe": {
         "prefix": "iframe",
-        "body": "<iframe src=\"$1\">$2</iframe>$3",
+        "body": "<iframe src=\"$1\" width=\"$2\" height=\"$3\"></iframe>",
         "description": "Defines a frame for embedding another document"
     },
     "img": {
         "prefix": "img",
-        "body": "<img src=\"$1\" alt=\"$2\">$3",
+        "body": "<img src=\"$1\" width=\"$2\" height=\"$3\" alt=\"$4\">",
         "description": "Defines an image"
     },
     "input": {
         "prefix": "input",
-        "body": "<input type=\"$1\" name=\"$2\" value=\"$3\">$4",
+        "body": "<input type=\"$1\" name=\"$2\" value=\"$3\">",
         "description": "Defines an input field"
     },
     "ins": {
         "prefix": "ins",
-        "body": "<ins>$1</ins>$2",
+        "body": "<ins>$1</ins>",
         "description": "Defines inserted text"
     },
     "kbd": {
         "prefix": "kbd",
-        "body": "<kbd>$1</kbd>$2",
-        "description": "Defines keyboard text"
+        "body": "<kbd>$1</kbd>",
+        "description": "Defines keyboard input"
     },
     "label": {
         "prefix": "label",
-        "body": "<label for=\"$1\">$2</label>$3",
+        "body": "<label for=\"$1\">$2</label>",
         "description": "Defines a label for a form element"
     },
     "legend": {
         "prefix": "legend",
-        "body": "<legend>$1</legend>$2",
+        "body": "<legend>$1</legend>",
         "description": "Defines a title in a fieldset"
     },
     "li": {
         "prefix": "li",
-        "body": "<li>$1</li>$2",
+        "body": "<li>$1</li>",
         "description": "Defines a list item"
     },
     "link": {
         "prefix": "link",
-        "body": "<link rel=\"$1\" type=\"$2\" href=\"$3\">$4",
+        "body": "<link rel=\"$1\" type=\"$2\" href=\"$3\">",
         "description": "Defines a resource reference"
     },
     "main": {
         "prefix": "main",
-        "body": ["<main>", "\t$1", "</main>"],
+        "body": ["<main>", "\t$0", "</main>"],
         "description": "Defines the main content of the document"
     },
     "map": {
         "prefix": "map",
-        "body": ["<map name=\"$1\">", "\t$2", "</map>"],
+        "body": ["<map name=\"$1\">", "\t$0", "</map>"],
         "description": "Defines an image map"
     },
     "mark": {
         "prefix": "mark",
-        "body": "<mark>$1</mark>$2",
+        "body": "<mark>$1</mark>",
         "description": "Defines marked text"
     },
     "menu": {
         "prefix": "menu",
-        "body": ["<menu>", "\t$1", "</menu>"],
+        "body": ["<menu>", "\t$0", "</menu>"],
         "description": "Defines a menu list"
     },
     "meta": {
         "prefix": "meta",
-        "body": "<meta name=\"$1\" content=\"$2\">$3",
-        "description": "Defines meta information"
+        "body": "<meta name=\"$1\" content=\"$2\">",
+        "description": "Defines metadata about the documentn"
     },
     "meter": {
         "prefix": "meter",
-        "body": "<meter value=\"$1\">$2</meter>$3",
+        "body": "<meter min=\"$1\" max=\"$2\" value=\"$3\">$4</meter>",
         "description": "Defines measurement within a predefined range"
     },
     "nav": {
         "prefix": "nav",
-        "body": ["<nav>", "\t$1", "</nav>"],
+        "body": ["<nav>", "\t$0", "</nav>"],
         "description": "Defines navigation links"
     },
     "noscript": {
         "prefix": "noscript",
-        "body": ["<noscript>", "$1", "</noscript>"],
-        "description": "Defines a noscript section"
+        "body": "<noscript>$1</noscript>",
+        "description": "Defines content to show when scripts are disabled or unsupported"
     },
     "object": {
         "prefix": "object",
-        "body": "<object width=\"$1\" height=\"$2\" data=\"$3\">$4</object>$5",
+        "body": "<object width=\"$1\" height=\"$2\" data=\"$3\">$4</object>",
         "description": "Defines an embedded object"
     },
     "ol": {
         "prefix": "ol",
-        "body": ["<ol>", "\t$1", "</ol>"],
+        "body": ["<ol>", "\t$0", "</ol>"],
+        "description": "Defines an ordered list"
+    },
+    "ol.": {
+        "prefix": "ol.",
+        "body": ["<ol class=\"$1\">", "\t$0", "</ol>"],
         "description": "Defines an ordered list"
     },
     "optgroup": {
         "prefix": "optgroup",
-        "body": ["<optgroup>", "\t$1", "</optgroup>"],
+        "body": ["<optgroup label=\"$1\">", "\t$0", "</optgroup>"],
         "description": "Defines an option group"
     },
     "option": {
         "prefix": "option",
-        "body": "<option value=\"$1\">$2</option>$3",
+        "body": "<option value=\"$1\">$2</option>",
         "description": "Defines an option in a drop-down list"
     },
     "output": {
         "prefix": "output",
-        "body": "<output name=\"$1\" for=\"$2\">$3</output>$4",
-        "description": "Defines some types of output"
+        "body": "<output name=\"$1\" for=\"$2\">$3</output>",
+        "description": "Defines the result of a calculation or user action"
     },
     "p": {
         "prefix": "p",
-        "body": "<p>$1</p>$2",
+        "body": ["<p>", "\t$1", "</p>"],
+        "description": "Defines a paragraph"
+    },
+    "p.": {
+        "prefix": "p.",
+        "body": ["<p class=\"$1\">", "\t$2", "</p>"],
         "description": "Defines a paragraph"
     },
     "param": {
         "prefix": "param",
-        "body": "<param name=\"$1\" value=\"$2\">$3",
+        "body": "<param name=\"$1\" value=\"$2\">",
         "description": "Defines a parameter for an object [DEPRECATED]"
     },
     "pre": {
         "prefix": "pre",
-        "body": ["<pre>$1</pre>"],
+        "body": "<pre>$0</pre>",
         "description": "Defines preformatted text"
     },
     "progress": {
         "prefix": "progress",
-        "body": "<progress value=\"$1\" max=\"$2\">$3</progress>$4",
+        "body": "<progress value=\"$1\" max=\"$2\">$3</progress>",
         "description": "Defines a visual indicator of task completion"
     },
     "q": {
         "prefix": "q",
-        "body": "<q>$1</q>$2",
+        "body": "<q>$1</q>",
         "description": "Defines a short quotation"
     },
     "rp": {
         "prefix": "rp",
-        "body": "<rp>$1</rp>$2",
-        "description": "Used in ruby annotations to define what to show browsers that do not support the ruby element"
+        "body": "<rp>$1</rp>",
+        "description": "Defines what to show to browsers that do not support the ruby element"
     },
     "rt": {
         "prefix": "rt",
-        "body": "<rt>$1</rt>$2",
+        "body": "<rt>$1</rt>",
         "description": "Defines explanation to ruby annotations"
     },
     "ruby": {
         "prefix": "ruby",
-        "body": ["<ruby>", "$1", "</ruby>"],
+        "body": "<ruby>$1</ruby>",
         "description": "Defines ruby annotations"
     },
     "s": {
         "prefix": "s",
-        "body": "<s>$1</s>$2",
-        "description": "Used to define strikethrough text"
+        "body": "<s>$1</s>",
+        "description": "Defines strikethrough text"
     },
     "samp": {
         "prefix": "samp",
-        "body": "<samp>$1</samp>$2",
+        "body": "<samp>$1</samp>",
         "description": "Defines sample computer code"
     },
     "script": {
         "prefix": "script",
-        "body": ["<script>", "\t$1", "</script>"],
-        "description": "Defines a script"
+        "body": "<script src=\"$1\"></script>",
+        "description": "Defines a script or links to an external script"
     },
     "section": {
         "prefix": "section",
-        "body": ["<section>", "\t$1", "</section>"],
-        "description": "Defines a section"
+        "body": ["<section>", "\t$0", "</section>"],
+        "description": "Defines a section in a document"
     },
     "select": {
         "prefix": "select",
-        "body": ["<select>", "\t$1", "</select>"],
-        "description": "Defines a selectable list"
+        "body": ["<select name=\"$1\">", "\t$0", "</select>"],
+        "description": "Defines a selectable list with options"
     },
     "small": {
         "prefix": "small",
-        "body": "<small>$1</small>$2",
+        "body": "<small>$1</small>",
         "description": "Defines small text"
     },
     "source": {
         "prefix": "source",
-        "body": "<source src=\"$1\" type=\"$2\">$3",
-        "description": "Defines media resource"
+        "body": "<source src=\"$1\" type=\"$2\">",
+        "description": "Defines media source"
     },
     "span": {
         "prefix": "span",
-        "body": "<span>$1</span>$2",
+        "body": "<span>$1</span>",
+        "description": "Defines a generic inline container"
+    },
+    "span.": {
+        "prefix": "span.",
+        "body": "<span class=\"$1\">\t$2</span>",
         "description": "Defines a generic inline container"
     },
     "strong": {
         "prefix": "strong",
-        "body": "<strong>$1</strong>$2",
-        "description": "Defines strong text"
+        "body": "<strong>$1</strong>",
+        "description": "Defines text of strong importance"
     },
     "style": {
         "prefix": "style",
-        "body": ["<style>", "$1", "</style>"],
-        "description": "Defines a style definition"
+        "body": ["<style>", "$0", "</style>"],
+        "description": "Defines style rules for a document"
     },
     "sub": {
         "prefix": "sub",
-        "body": "<sub>$1</sub>$2",
-        "description": "Defines sub-scripted text"
+        "body": "<sub>$1</sub>",
+        "description": "Defines subscript text"
     },
     "sup": {
         "prefix": "sup",
-        "body": "<sup>$1</sup>$2",
-        "description": "Defines super-scripted text"
+        "body": "<sup>$1</sup>",
+        "description": "Defines superscript text"
     },
     "summary": {
         "prefix": "summary",
-        "body": "<summary>$1</summary>$2",
+        "body": "<summary>$1</summary>",
         "description": "Defines a summary or label for a details element"
     },
     "table": {
         "prefix": "table",
-        "body": ["<table>", "\t$1", "</table>"],
+        "body": ["<table>", "\t$0", "</table>"],
         "description": "Defines a table"
     },
     "tbody": {
         "prefix": "tbody",
-        "body": ["<tbody>", "\t$1", "</tbody>"],
+        "body": ["<tbody>", "\t$0", "</tbody>"],
         "description": "Defines a table body"
     },
     "td": {
         "prefix": "td",
-        "body": "<td>$1</td>$2",
+        "body": "<td>$1</td>",
         "description": "Defines a table cell"
     },
     "textarea": {
         "prefix": "textarea",
-        "body": "<textarea rows=\"$1\" cols=\"$2\">$3</textarea>$4",
+        "body": "<textarea rows=\"$1\" cols=\"$2\">$3</textarea>",
         "description": "Defines a text area"
     },
     "tfoot": {
         "prefix": "tfoot",
-        "body": ["<tfoot>", "\t$1", "</tfoot>"],
+        "body": ["<tfoot>", "\t$0", "</tfoot>"],
         "description": "Defines a table footer"
     },
     "thead": {
         "prefix": "thead",
-        "body": ["<thead>", "$1", "</thead>"],
+        "body": ["<thead>", "\t$0", "</thead>"],
         "description": "Defines a table head"
     },
     "th": {
         "prefix": "th",
-        "body": "<th>$1</th>$2",
+        "body": "<th>$1</th>",
         "description": "Defines a table header"
     },
     "time": {
         "prefix": "time",
-        "body": "<time datetime=\"$1\">$2</time>$3",
+        "body": "<time datetime=\"$1\">$2</time>",
         "description": "Defines a machine-readable date or time"
     },
     "title": {
         "prefix": "title",
-        "body": "<title>$1</title>$2",
+        "body": "<title>$1</title>",
         "description": "Defines the document title"
     },
     "tr": {
         "prefix": "tr",
-        "body": "<tr>$1</tr>$2",
+        "body": ["<tr>", "\t$0", "</tr>"],
         "description": "Defines a table row"
     },
     "track": {
         "prefix": "track",
-        "body": "<track src=\"$1\" kind=\"$2\" srclang=\"$3\" label=\"$4\">$5",
+        "body": "<track src=\"$1\" kind=\"$2\" srclang=\"$3\" label=\"$4\">",
         "description": "Defines text tracks for video or audio"
     },
     "u": {
         "prefix": "u",
-        "body": "<u>$1</u>$2",
-        "description": "Used to define underlined text"
+        "body": "<u>$1</u>",
+        "description": "Defines underlined text"
     },
     "ul": {
         "prefix": "ul",
-        "body": ["<ul>", "\t$1", "</ul>"],
+        "body": ["<ul>", "\t$0", "</ul>"],
+        "description": "Defines an unordered list"
+    },
+    "ul.": {
+        "prefix": "ul.",
+        "body": ["<ul class=\"$1\">", "\t$0", "</ul>"],
         "description": "Defines an unordered list"
     },
     "var": {
         "prefix": "var",
-        "body": "<var>$1</var>$2",
-        "description": "Defines a variable"
+        "body": "<var>$1</var>",
+        "description": "Defines text representing a variable"
     },
     "video": {
         "prefix": "video",
         "body": [
-            "<video width=\"$1\" height=\"$2\" controls>",
+            "<video controls src=\"$1\" width=\"$2\" height=\"$3\">",
             "\t$3",
             "</video>"
         ],
-        "description": "Defines a video"
-    },
-"div.": {
-        "prefix": "div.",
-        "body": ["<div class=\"$1\">", "\t$2", "</div>"],
-        "description": "Defines a generic block-level container"
-    },
-"div#": {
-        "prefix": "div#",
-        "body": ["<div id=\"$1\">", "\t$2", "</div>"],
-        "description": "Defines a generic block-level container"
-    },
-"div.#": {
-        "prefix": "div.#",
-        "body": ["<div class=\"$1\" id=\"$2\">", "\t$3", "</div>"],
-        "description": "Defines a generic block-level container"
-    },
-"p.": {
-        "prefix": "p.",
-        "body": ["<p class=\"$1\">$2</p>"],
-        "description": "Defines a paragraph"
-    },
-"p#": {
-        "prefix": "p#",
-        "body": ["<p id=\"$1\">$2</p>"],
-        "description": "Defines a paragraph"
-    },
-"p.#": {
-        "prefix": "p.#",
-        "body": ["<p class=\"$1\" id=\"$2\">$3</p>"],
-        "description": "Defines a paragraph"
-    },
-"ul.": {
-        "prefix": "ul.",
-        "body": ["<ul class=\"$1\">", "\t$2", "</ul>"],
-        "description": "Defines an unordered list"
-    },
-"ul#": {
-        "prefix": "ul#",
-        "body": ["<ul id=\"$1\">", "\t$2", "</ul>"],
-        "description": "Defines an unordered list"
-    },
-"ul.#": {
-        "prefix": "ul.#",
-        "body": ["<ul class=\"$1\" id=\"$2\">", "\t$3", "</ul>"],
-        "description": "Defines an unordered list"
-    },
-"ol.": {
-        "prefix": "ol.",
-        "body": ["<ol class=\"$1\">", "\t$2", "</ol>"],
-        "description": "Defines an ordered list"
-    },
-"ol#": {
-        "prefix": "ol#",
-        "body": ["<ol id=\"$1\">", "\t$2", "</ol>"],
-        "description": "Defines an ordered list"
-    },
-"ol.#": {
-        "prefix": "ol.#",
-        "body": ["<ol class=\"$1\" id=\"$2\">", "\t$3", "</ol>"],
-        "description": "Defines an ordered list"
+        "description": "Defines a video embed"
     }
 }

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -62,7 +62,7 @@
     "audio": {
         "prefix": "audio",
         "body": ["<audio controls>", "\t$1", "</audio>"],
-        "description": "HTML - Defines sounds content",
+        "description": "HTML - Defines embedded audio content",
         "scope": "text.html"
     },
     "b": {
@@ -92,7 +92,7 @@
     "big": {
         "prefix": "big",
         "body": "<big>$1</big>$2",
-        "description": "HTML - Used to make text bigger",
+        "description": "HTML - Used to make text bigger [DEPRECATED]",
         "scope": "text.html"
     },
     "blockquote": {
@@ -122,7 +122,7 @@
     "canvas": {
         "prefix": "canvas",
         "body": "<canvas id=\"$1\">$2</canvas>$3",
-        "description": "HTML - Defines graphics",
+        "description": "HTML - Defines a container for graphics drawn with JavaScript",
         "scope": "text.html"
     },
     "caption": {
@@ -153,12 +153,6 @@
         "prefix": "colgroup",
         "body": ["<colgroup>", "\t$1", "</colgroup>"],
         "description": "HTML - Defines group of table columns",
-        "scope": "text.html"
-    },
-    "command": {
-        "prefix": "command",
-        "body": "<command>$1</command>$2",
-        "description": "HTML - Defines a command button [not supported]",
         "scope": "text.html"
     },
     "datalist": {
@@ -242,7 +236,7 @@
     "figure": {
         "prefix": "figure",
         "body": ["<figure>", "\t$1", "</figure>"],
-        "description": "HTML - Defines a group of media content, and their caption",
+        "description": "HTML - Defines self‑contained content with an optional caption",
         "scope": "text.html"
     },
     "footer": {
@@ -372,12 +366,6 @@
         "description": "HTML - Defines inserted text",
         "scope": "text.html"
     },
-    "keygen": {
-        "prefix": "keygen",
-        "body": "<keygen name=\"$1\">$2",
-        "description": "HTML - Defines a generated key in a form",
-        "scope": "text.html"
-    },
     "kbd": {
         "prefix": "kbd",
         "body": "<kbd>$1</kbd>$2",
@@ -430,12 +418,6 @@
         "prefix": "menu",
         "body": ["<menu>", "\t$1", "</menu>"],
         "description": "HTML - Defines a menu list",
-        "scope": "text.html"
-    },
-    "menuitem": {
-        "prefix": "menuitem",
-        "body": "<menuitem>$1</menuitem>$2",
-        "description": "HTML - Defines a menu item [firefox only]",
         "scope": "text.html"
     },
     "meta": {
@@ -501,7 +483,7 @@
     "param": {
         "prefix": "param",
         "body": "<param name=\"$1\" value=\"$2\">$3",
-        "description": "HTML - Defines a parameter for an object",
+        "description": "HTML - Defines a parameter for an object [DEPRECATED]",
         "scope": "text.html"
     },
     "pre": {
@@ -513,7 +495,7 @@
     "progress": {
         "prefix": "progress",
         "body": "<progress value=\"$1\" max=\"$2\">$3</progress>$4",
-        "description": "HTML - Defines progress of a task of any kind",
+        "description": "HTML - Defines a visual indicator of task completion",
         "scope": "text.html"
     },
     "q": {
@@ -615,7 +597,7 @@
     "summary": {
         "prefix": "summary",
         "body": "<summary>$1</summary>$2",
-        "description": "HTML - Defines a visible heading for the detail element [limited support]",
+        "description": "HTML - Defines a summary or label for a details element",
         "scope": "text.html"
     },
     "table": {
@@ -663,7 +645,7 @@
     "time": {
         "prefix": "time",
         "body": "<time datetime=\"$1\">$2</time>$3",
-        "description": "HTML - Defines a date/time",
+        "description": "HTML - Defines a machine-readable date or time",
         "scope": "text.html"
     },
     "title": {

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -121,6 +121,11 @@
         "body": "<cite>$1</cite>",
         "description": "Defines the title of a creative work"
     },
+    "class (attribute)": {
+        "prefix": "class",
+        "body": "class=\"$1\"",
+        "description": "Defines one or more class names for an element"
+    },
     "code": {
         "prefix": "code",
         "body": "<code>$1</code>",
@@ -300,6 +305,11 @@
         "prefix": "i",
         "body": "<i>$1</i>",
         "description": "Defines text with alternate emphasis"
+    },
+    "id (attribute)": {
+        "prefix": "id",
+        "body": "id=\"$1\"",
+        "description": "Defines a unique identifier for an element"
     },
     "iframe": {
         "prefix": "iframe",
@@ -540,6 +550,11 @@
         "prefix": "style",
         "body": ["<style>", "$0", "</style>"],
         "description": "Defines style rules for a document"
+    },
+    "style (attribute)": {
+        "prefix": "style",
+        "body": "style=\"$1\"",
+        "description": "Defines inline CSS styles for an element"
     },
     "sub": {
         "prefix": "sub",

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -14,308 +14,257 @@
             "</body>",
             "</html>"
         ],
-        "description": "HTML - Defines a template for a html5 document",
-        "scope": "text.html"
+        "description": "Defines a template for a html5 document"
     },
     "doctype": {
         "prefix": "doctype",
         "body": ["<!DOCTYPE>", "$1"],
-        "description": "HTML - Defines the document type",
-        "scope": "text.html"
+        "description": "Defines the document type"
     },
     "a": {
         "prefix": "a",
         "body": "<a href=\"$1\">$2</a>$3",
-        "description": "HTML - Defines a hyperlink",
-        "scope": "text.html"
+        "description": "Defines a hyperlink"
     },
     "abbr": {
         "prefix": "abbr",
         "body": "<abbr title=\"$1\">$2</abbr>$3",
-        "description": "HTML - Defines an abbreviation",
-        "scope": "text.html"
+        "description": "Defines an abbreviation"
     },
     "address": {
         "prefix": "address",
         "body": ["<address>", "$1", "</address>"],
-        "description": "HTML - Defines an address element",
-        "scope": "text.html"
+        "description": "Defines an address element"
     },
     "area": {
         "prefix": "area",
         "body": "<area shape=\"$1\" coords=\"$2\" href=\"$3\" alt=\"$4\">$5",
-        "description": "HTML - Defines an area inside an image map",
-        "scope": "text.html"
+        "description": "Defines an area inside an image map"
     },
     "article": {
         "prefix": "article",
         "body": ["<article>", "\t$1", "</article>"],
-        "description": "HTML - Defines an article",
-        "scope": "text.html"
+        "description": "Defines an article"
     },
     "aside": {
         "prefix": "aside",
         "body": ["<aside>", "\t$1", "</aside>$2"],
-        "description": "HTML - Defines content aside from the page content",
-        "scope": "text.html"
+        "description": "Defines content aside from the page content"
     },
     "audio": {
         "prefix": "audio",
         "body": ["<audio controls>", "\t$1", "</audio>"],
-        "description": "HTML - Defines embedded audio content",
-        "scope": "text.html"
+        "description": "Defines embedded audio content"
     },
     "b": {
         "prefix": "b",
         "body": "<b>$1</b>$2",
-        "description": "HTML - Defines bold text",
-        "scope": "text.html"
+        "description": "Defines bold text"
     },
     "base": {
         "prefix": "base",
         "body": "<base href=\"$1\" target=\"$2\">$3",
-        "description": "HTML - Defines a base URL for all the links in a page",
-        "scope": "text.html"
+        "description": "Defines a base URL for all the links in a page"
     },
     "bdi": {
         "prefix": "bdi",
         "body": "<bdi>$1</bdi>$2",
-        "description": "HTML - Used to isolate text that is of unknown directionality",
-        "scope": "text.html"
+        "description": "Used to isolate text that is of unknown directionality"
     },
     "bdo": {
         "prefix": "bdo",
         "body": ["<bdo dir=\"$1\">", "$2", "</bdo>"],
-        "description": "HTML - Defines the direction of text display",
-        "scope": "text.html"
+        "description": "Defines the direction of text display"
     },
     "big": {
         "prefix": "big",
         "body": "<big>$1</big>$2",
-        "description": "HTML - Used to make text bigger [DEPRECATED]",
-        "scope": "text.html"
+        "description": "Used to make text bigger [DEPRECATED]"
     },
     "blockquote": {
         "prefix": "blockquote",
         "body": ["<blockquote cite=\"$2\">", "\t$1", "</blockquote>"],
-        "description": "HTML - Defines a long quotation",
-        "scope": "text.html"
+        "description": "Defines a long quotation"
     },
     "body": {
         "prefix": "body",
         "body": ["<body>", "\t$0", "</body>"],
-        "description": "HTML - Defines the body element",
-        "scope": "text.html"
+        "description": "Defines the body element"
     },
     "br": {
         "prefix": "br",
         "body": "<br>",
-        "description": "HTML - Inserts a single line break",
-        "scope": "text.html"
+        "description": "Inserts a single line break"
     },
     "button": {
         "prefix": "button",
         "body": "<button type=\"$1\">$2</button>$3",
-        "description": "HTML - Defines a push button",
-        "scope": "text.html"
+        "description": "Defines a push button"
     },
     "canvas": {
         "prefix": "canvas",
         "body": "<canvas id=\"$1\">$2</canvas>$3",
-        "description": "HTML - Defines a container for graphics drawn with JavaScript",
-        "scope": "text.html"
+        "description": "Defines a container for graphics drawn with JavaScript"
     },
     "caption": {
         "prefix": "caption",
         "body": "<caption>$1</caption>$2",
-        "description": "HTML - Defines a table caption",
-        "scope": "text.html"
+        "description": "Defines a table caption"
     },
     "cite": {
         "prefix": "cite",
         "body": "<cite>$1</cite>$2",
-        "description": "HTML - Defines a citation",
-        "scope": "text.html"
+        "description": "Defines a citation"
     },
     "code": {
         "prefix": "code",
         "body": "<code>$1</code>$2",
-        "description": "HTML - Defines computer code text",
-        "scope": "text.html"
+        "description": "Defines computer code text"
     },
     "col": {
         "prefix": "col",
         "body": "<col>$2",
-        "description": "HTML - Defines attributes for table columns",
-        "scope": "text.html"
+        "description": "Defines attributes for table columns"
     },
     "colgroup": {
         "prefix": "colgroup",
         "body": ["<colgroup>", "\t$1", "</colgroup>"],
-        "description": "HTML - Defines group of table columns",
-        "scope": "text.html"
+        "description": "Defines group of table columns"
     },
     "datalist": {
         "prefix": "datalist",
         "body": ["<datalist>", "\t$1", "</datalist>"],
-        "description": "HTML - Defines a dropdown list",
-        "scope": "text.html"
+        "description": "Defines a dropdown list"
     },
     "dd": {
         "prefix": "dd",
         "body": "<dd>$1</dd>$2",
-        "description": "HTML - Defines a definition description",
-        "scope": "text.html"
+        "description": "Defines a definition description"
     },
     "del": {
         "prefix": "del",
         "body": "<del>$1</del>$2",
-        "description": "HTML - Defines deleted text",
-        "scope": "text.html"
+        "description": "Defines deleted text"
     },
     "details": {
         "prefix": "details",
         "body": ["<details>", "\t$1", "</details>"],
-        "description": "HTML - Defines details of an element",
-        "scope": "text.html"
+        "description": "Defines details of an element"
     },
     "dialog": {
         "prefix": "dialog",
         "body": "<dialog>$1</dialog>$2",
-        "description": "HTML - Defines a dialog box or modal window",
-        "scope": "text.html"
+        "description": "Defines a dialog box or modal window"
     },
     "dfn": {
         "prefix": "dfn",
         "body": "<dfn>$1</dfn>$2",
-        "description": "HTML - Defines a definition term",
-        "scope": "text.html"
+        "description": "Defines a definition term"
     },
     "div": {
         "prefix": "div",
         "body": ["<div>", "\t$1", "</div>"],
-        "description": "HTML - Defines a generic block-level container",
-        "scope": "text.html"
+        "description": "Defines a generic block-level container"
     },
     "dl": {
         "prefix": "dl",
         "body": ["<dl>", "\t$1", "</dl>"],
-        "description": "HTML - Defines a definition list",
-        "scope": "text.html"
+        "description": "Defines a definition list"
     },
     "dt": {
         "prefix": "dt",
         "body": "<dt>$1</dt>$2",
-        "description": "HTML - Defines a definition term",
-        "scope": "text.html"
+        "description": "Defines a definition term"
     },
     "em": {
         "prefix": "em",
         "body": "<em>$1</em>$2",
-        "description": "HTML - Defines emphasized text",
-        "scope": "text.html"
+        "description": "Defines emphasized text"
     },
     "embed": {
         "prefix": "embed",
         "body": "<embed src=\"$1\">$2",
-        "description": "HTML - Defines external interactive content or plugin",
-        "scope": "text.html"
+        "description": "Defines external interactive content or plugin"
     },
     "fieldset": {
         "prefix": "fieldset",
         "body": ["<fieldset>", "\t$1", "</fieldset>"],
-        "description": "HTML - Defines a fieldset",
-        "scope": "text.html"
+        "description": "Defines a fieldset"
     },
     "figcaption": {
         "prefix": "figcaption",
         "body": "<figcaption>$1</figcaption>$2",
-        "description": "HTML - Defines a caption for a figure",
-        "scope": "text.html"
+        "description": "Defines a caption for a figure"
     },
     "figure": {
         "prefix": "figure",
         "body": ["<figure>", "\t$1", "</figure>"],
-        "description": "HTML - Defines self‑contained content with an optional caption",
-        "scope": "text.html"
+        "description": "Defines self‑contained content with an optional caption"
     },
     "footer": {
         "prefix": "footer",
         "body": ["<footer>", "\t$1", "</footer>"],
-        "description": "HTML - Defines a footer for a section or page",
-        "scope": "text.html"
+        "description": "Defines a footer for a section or page"
     },
     "form": {
         "prefix": "form",
         "body": ["<form>", "\t$1", "</form>"],
-        "description": "HTML - Defines a form",
-        "scope": "text.html"
+        "description": "Defines a form"
     },
     "h1": {
         "prefix": "h1",
         "body": "<h1>$1</h1>$2",
-        "description": "HTML - Defines header 1",
-        "scope": "text.html"
+        "description": "Defines header 1"
     },
     "h2": {
         "prefix": "h2",
         "body": "<h2>$1</h2>$2",
-        "description": "HTML - Defines header 2",
-        "scope": "text.html"
+        "description": "Defines header 2"
     },
     "h3": {
         "prefix": "h3",
         "body": "<h3>$1</h3>$2",
-        "description": "HTML - Defines header 3",
-        "scope": "text.html"
+        "description": "Defines header 3"
     },
     "h4": {
         "prefix": "h4",
         "body": "<h4>$1</h4>$2",
-        "description": "HTML - Defines header 4",
-        "scope": "text.html"
+        "description": "Defines header 4"
     },
     "h5": {
         "prefix": "h5",
         "body": "<h5>$1</h5>$2",
-        "description": "HTML - Defines header 5",
-        "scope": "text.html"
+        "description": "Defines header 5"
     },
     "h6": {
         "prefix": "h6",
         "body": "<h6>$1</h6>$2",
-        "description": "HTML - Defines header 6",
-        "scope": "text.html"
+        "description": "Defines header 6"
     },
     "head": {
         "prefix": "head",
         "body": ["<head>", "\t$1", "</head>"],
-        "description": "HTML - Defines information about the document",
-        "scope": "text.html"
+        "description": "Defines information about the document"
     },
     "header": {
         "prefix": "header",
         "body": ["<header>", "\t$1", "</header>"],
-        "description": "HTML - Defines a header for a section of page",
-        "scope": "text.html"
+        "description": "Defines a header for a section of page"
     },
     "hgroup": {
         "prefix": "hgroup",
         "body": ["<hgroup>", "\t$1", "</hgroup>"],
-        "description": "HTML - Defines a heading grouped with subtitle or related text",
-        "scope": "text.html"
+        "description": "Defines a heading grouped with subtitle or related text"
     },
     "hr": {
         "prefix": "hr",
         "body": "<hr>",
-        "description": "HTML - Defines a horizontal rule",
-        "scope": "text.html"
+        "description": "Defines a horizontal rule"
     },
     "html": {
         "prefix": "html",
         "body": ["<html>", "\t$0", "</html>"],
-        "description": "HTML - Defines an html document",
-        "scope": "text.html"
+        "description": "Defines an html document"
     },
     "html5": {
         "prefix": "html5",
@@ -333,356 +282,297 @@
             "\t</body>",
             "</html>"
         ],
-        "description": "HTML - Defines a template for a html5 document",
-        "scope": "text.html"
+        "description": "Defines a template for a html5 document"
     },
     "i": {
         "prefix": "i",
         "body": "<i>$1</i>$2",
-        "description": "HTML - Defines italic text",
-        "scope": "text.html"
+        "description": "Defines italic text"
     },
     "iframe": {
         "prefix": "iframe",
         "body": "<iframe src=\"$1\">$2</iframe>$3",
-        "description": "HTML - Defines a frame for embedding another document",
-        "scope": "text.html"
+        "description": "Defines a frame for embedding another document"
     },
     "img": {
         "prefix": "img",
         "body": "<img src=\"$1\" alt=\"$2\">$3",
-        "description": "HTML - Defines an image",
-        "scope": "text.html"
+        "description": "Defines an image"
     },
     "input": {
         "prefix": "input",
         "body": "<input type=\"$1\" name=\"$2\" value=\"$3\">$4",
-        "description": "HTML - Defines an input field",
-        "scope": "text.html"
+        "description": "Defines an input field"
     },
     "ins": {
         "prefix": "ins",
         "body": "<ins>$1</ins>$2",
-        "description": "HTML - Defines inserted text",
-        "scope": "text.html"
+        "description": "Defines inserted text"
     },
     "kbd": {
         "prefix": "kbd",
         "body": "<kbd>$1</kbd>$2",
-        "description": "HTML - Defines keyboard text",
-        "scope": "text.html"
+        "description": "Defines keyboard text"
     },
     "label": {
         "prefix": "label",
         "body": "<label for=\"$1\">$2</label>$3",
-        "description": "HTML - Defines a label for a form element",
-        "scope": "text.html"
+        "description": "Defines a label for a form element"
     },
     "legend": {
         "prefix": "legend",
         "body": "<legend>$1</legend>$2",
-        "description": "HTML - Defines a title in a fieldset",
-        "scope": "text.html"
+        "description": "Defines a title in a fieldset"
     },
     "li": {
         "prefix": "li",
         "body": "<li>$1</li>$2",
-        "description": "HTML - Defines a list item",
-        "scope": "text.html"
+        "description": "Defines a list item"
     },
     "link": {
         "prefix": "link",
         "body": "<link rel=\"$1\" type=\"$2\" href=\"$3\">$4",
-        "description": "HTML - Defines a resource reference",
-        "scope": "text.html"
+        "description": "Defines a resource reference"
     },
     "main": {
         "prefix": "main",
         "body": ["<main>", "\t$1", "</main>"],
-        "description": "HTML - Defines the main content of the document",
-        "scope": "text.html"
+        "description": "Defines the main content of the document"
     },
     "map": {
         "prefix": "map",
         "body": ["<map name=\"$1\">", "\t$2", "</map>"],
-        "description": "HTML - Defines an image map",
-        "scope": "text.html"
+        "description": "Defines an image map"
     },
     "mark": {
         "prefix": "mark",
         "body": "<mark>$1</mark>$2",
-        "description": "HTML - Defines marked text",
-        "scope": "text.html"
+        "description": "Defines marked text"
     },
     "menu": {
         "prefix": "menu",
         "body": ["<menu>", "\t$1", "</menu>"],
-        "description": "HTML - Defines a menu list",
-        "scope": "text.html"
+        "description": "Defines a menu list"
     },
     "meta": {
         "prefix": "meta",
         "body": "<meta name=\"$1\" content=\"$2\">$3",
-        "description": "HTML - Defines meta information",
-        "scope": "text.html"
+        "description": "Defines meta information"
     },
     "meter": {
         "prefix": "meter",
         "body": "<meter value=\"$1\">$2</meter>$3",
-        "description": "HTML - Defines measurement within a predefined range",
-        "scope": "text.html"
+        "description": "Defines measurement within a predefined range"
     },
     "nav": {
         "prefix": "nav",
         "body": ["<nav>", "\t$1", "</nav>"],
-        "description": "HTML - Defines navigation links",
-        "scope": "text.html"
+        "description": "Defines navigation links"
     },
     "noscript": {
         "prefix": "noscript",
         "body": ["<noscript>", "$1", "</noscript>"],
-        "description": "HTML - Defines a noscript section",
-        "scope": "text.html"
+        "description": "Defines a noscript section"
     },
     "object": {
         "prefix": "object",
         "body": "<object width=\"$1\" height=\"$2\" data=\"$3\">$4</object>$5",
-        "description": "HTML - Defines an embedded object",
-        "scope": "text.html"
+        "description": "Defines an embedded object"
     },
     "ol": {
         "prefix": "ol",
         "body": ["<ol>", "\t$1", "</ol>"],
-        "description": "HTML - Defines an ordered list",
-        "scope": "text.html"
+        "description": "Defines an ordered list"
     },
     "optgroup": {
         "prefix": "optgroup",
         "body": ["<optgroup>", "\t$1", "</optgroup>"],
-        "description": "HTML - Defines an option group",
-        "scope": "text.html"
+        "description": "Defines an option group"
     },
     "option": {
         "prefix": "option",
         "body": "<option value=\"$1\">$2</option>$3",
-        "description": "HTML - Defines an option in a drop-down list",
-        "scope": "text.html"
+        "description": "Defines an option in a drop-down list"
     },
     "output": {
         "prefix": "output",
         "body": "<output name=\"$1\" for=\"$2\">$3</output>$4",
-        "description": "HTML - Defines some types of output",
-        "scope": "text.html"
+        "description": "Defines some types of output"
     },
     "p": {
         "prefix": "p",
         "body": "<p>$1</p>$2",
-        "description": "HTML - Defines a paragraph",
-        "scope": "text.html"
+        "description": "Defines a paragraph"
     },
     "param": {
         "prefix": "param",
         "body": "<param name=\"$1\" value=\"$2\">$3",
-        "description": "HTML - Defines a parameter for an object [DEPRECATED]",
-        "scope": "text.html"
+        "description": "Defines a parameter for an object [DEPRECATED]"
     },
     "pre": {
         "prefix": "pre",
         "body": ["<pre>$1</pre>"],
-        "description": "HTML - Defines preformatted text",
-        "scope": "text.html"
+        "description": "Defines preformatted text"
     },
     "progress": {
         "prefix": "progress",
         "body": "<progress value=\"$1\" max=\"$2\">$3</progress>$4",
-        "description": "HTML - Defines a visual indicator of task completion",
-        "scope": "text.html"
+        "description": "Defines a visual indicator of task completion"
     },
     "q": {
         "prefix": "q",
         "body": "<q>$1</q>$2",
-        "description": "HTML - Defines a short quotation",
-        "scope": "text.html"
+        "description": "Defines a short quotation"
     },
     "rp": {
         "prefix": "rp",
         "body": "<rp>$1</rp>$2",
-        "description": "HTML - Used in ruby annotations to define what to show browsers that do not support the ruby element",
-        "scope": "text.html"
+        "description": "Used in ruby annotations to define what to show browsers that do not support the ruby element"
     },
     "rt": {
         "prefix": "rt",
         "body": "<rt>$1</rt>$2",
-        "description": "HTML - Defines explanation to ruby annotations",
-        "scope": "text.html"
+        "description": "Defines explanation to ruby annotations"
     },
     "ruby": {
         "prefix": "ruby",
         "body": ["<ruby>", "$1", "</ruby>"],
-        "description": "HTML - Defines ruby annotations",
-        "scope": "text.html"
+        "description": "Defines ruby annotations"
     },
     "s": {
         "prefix": "s",
         "body": "<s>$1</s>$2",
-        "description": "HTML - Used to define strikethrough text",
-        "scope": "text.html"
+        "description": "Used to define strikethrough text"
     },
     "samp": {
         "prefix": "samp",
         "body": "<samp>$1</samp>$2",
-        "description": "HTML - Defines sample computer code",
-        "scope": "text.html"
+        "description": "Defines sample computer code"
     },
     "script": {
         "prefix": "script",
         "body": ["<script>", "\t$1", "</script>"],
-        "description": "HTML - Defines a script",
-        "scope": "text.html"
+        "description": "Defines a script"
     },
     "section": {
         "prefix": "section",
         "body": ["<section>", "\t$1", "</section>"],
-        "description": "HTML - Defines a section",
-        "scope": "text.html"
+        "description": "Defines a section"
     },
     "select": {
         "prefix": "select",
         "body": ["<select>", "\t$1", "</select>"],
-        "description": "HTML - Defines a selectable list",
-        "scope": "text.html"
+        "description": "Defines a selectable list"
     },
     "small": {
         "prefix": "small",
         "body": "<small>$1</small>$2",
-        "description": "HTML - Defines small text",
-        "scope": "text.html"
+        "description": "Defines small text"
     },
     "source": {
         "prefix": "source",
         "body": "<source src=\"$1\" type=\"$2\">$3",
-        "description": "HTML - Defines media resource",
-        "scope": "text.html"
+        "description": "Defines media resource"
     },
     "span": {
         "prefix": "span",
         "body": "<span>$1</span>$2",
-        "description": "HTML - Defines a generic inline container",
-        "scope": "text.html"
+        "description": "Defines a generic inline container"
     },
     "strong": {
         "prefix": "strong",
         "body": "<strong>$1</strong>$2",
-        "description": "HTML - Defines strong text",
-        "scope": "text.html"
+        "description": "Defines strong text"
     },
     "style": {
         "prefix": "style",
         "body": ["<style>", "$1", "</style>"],
-        "description": "HTML - Defines a style definition",
-        "scope": "text.html"
+        "description": "Defines a style definition"
     },
     "sub": {
         "prefix": "sub",
         "body": "<sub>$1</sub>$2",
-        "description": "HTML - Defines sub-scripted text",
-        "scope": "text.html"
+        "description": "Defines sub-scripted text"
     },
     "sup": {
         "prefix": "sup",
         "body": "<sup>$1</sup>$2",
-        "description": "HTML - Defines super-scripted text",
-        "scope": "text.html"
+        "description": "Defines super-scripted text"
     },
     "summary": {
         "prefix": "summary",
         "body": "<summary>$1</summary>$2",
-        "description": "HTML - Defines a summary or label for a details element",
-        "scope": "text.html"
+        "description": "Defines a summary or label for a details element"
     },
     "table": {
         "prefix": "table",
         "body": ["<table>", "\t$1", "</table>"],
-        "description": "HTML - Defines a table",
-        "scope": "text.html"
+        "description": "Defines a table"
     },
     "tbody": {
         "prefix": "tbody",
         "body": ["<tbody>", "\t$1", "</tbody>"],
-        "description": "HTML - Defines a table body",
-        "scope": "text.html"
+        "description": "Defines a table body"
     },
     "td": {
         "prefix": "td",
         "body": "<td>$1</td>$2",
-        "description": "HTML - Defines a table cell",
-        "scope": "text.html"
+        "description": "Defines a table cell"
     },
     "textarea": {
         "prefix": "textarea",
         "body": "<textarea rows=\"$1\" cols=\"$2\">$3</textarea>$4",
-        "description": "HTML - Defines a text area",
-        "scope": "text.html"
+        "description": "Defines a text area"
     },
     "tfoot": {
         "prefix": "tfoot",
         "body": ["<tfoot>", "\t$1", "</tfoot>"],
-        "description": "HTML - Defines a table footer",
-        "scope": "text.html"
+        "description": "Defines a table footer"
     },
     "thead": {
         "prefix": "thead",
         "body": ["<thead>", "$1", "</thead>"],
-        "description": "HTML - Defines a table head",
-        "scope": "text.html"
+        "description": "Defines a table head"
     },
     "th": {
         "prefix": "th",
         "body": "<th>$1</th>$2",
-        "description": "HTML - Defines a table header",
-        "scope": "text.html"
+        "description": "Defines a table header"
     },
     "time": {
         "prefix": "time",
         "body": "<time datetime=\"$1\">$2</time>$3",
-        "description": "HTML - Defines a machine-readable date or time",
-        "scope": "text.html"
+        "description": "Defines a machine-readable date or time"
     },
     "title": {
         "prefix": "title",
         "body": "<title>$1</title>$2",
-        "description": "HTML - Defines the document title",
-        "scope": "text.html"
+        "description": "Defines the document title"
     },
     "tr": {
         "prefix": "tr",
         "body": "<tr>$1</tr>$2",
-        "description": "HTML - Defines a table row",
-        "scope": "text.html"
+        "description": "Defines a table row"
     },
     "track": {
         "prefix": "track",
         "body": "<track src=\"$1\" kind=\"$2\" srclang=\"$3\" label=\"$4\">$5",
-        "description": "HTML - Defines text tracks for video or audio",
-        "scope": "text.html"
+        "description": "Defines text tracks for video or audio"
     },
     "u": {
         "prefix": "u",
         "body": "<u>$1</u>$2",
-        "description": "HTML - Used to define underlined text",
-        "scope": "text.html"
+        "description": "Used to define underlined text"
     },
     "ul": {
         "prefix": "ul",
         "body": ["<ul>", "\t$1", "</ul>"],
-        "description": "HTML - Defines an unordered list",
-        "scope": "text.html"
+        "description": "Defines an unordered list"
     },
     "var": {
         "prefix": "var",
         "body": "<var>$1</var>$2",
-        "description": "HTML - Defines a variable",
-        "scope": "text.html"
+        "description": "Defines a variable"
     },
     "video": {
         "prefix": "video",
@@ -691,79 +581,66 @@
             "\t$3",
             "</video>"
         ],
-        "description": "HTML - Defines a video",
-        "scope": "text.html"
+        "description": "Defines a video"
     },
 "div.": {
         "prefix": "div.",
         "body": ["<div class=\"$1\">", "\t$2", "</div>"],
-        "description": "HTML - Defines a generic block-level container",
-        "scope": "text.html"
+        "description": "Defines a generic block-level container"
     },
 "div#": {
         "prefix": "div#",
         "body": ["<div id=\"$1\">", "\t$2", "</div>"],
-        "description": "HTML - Defines a generic block-level container",
-        "scope": "text.html"
+        "description": "Defines a generic block-level container"
     },
 "div.#": {
         "prefix": "div.#",
         "body": ["<div class=\"$1\" id=\"$2\">", "\t$3", "</div>"],
-        "description": "HTML - Defines a generic block-level container",
-        "scope": "text.html"
+        "description": "Defines a generic block-level container"
     },
 "p.": {
         "prefix": "p.",
         "body": ["<p class=\"$1\">$2</p>"],
-        "description": "HTML - Defines a paragraph",
-        "scope": "text.html"
+        "description": "Defines a paragraph"
     },
 "p#": {
         "prefix": "p#",
         "body": ["<p id=\"$1\">$2</p>"],
-        "description": "HTML - Defines a paragraph",
-        "scope": "text.html"
+        "description": "Defines a paragraph"
     },
 "p.#": {
         "prefix": "p.#",
         "body": ["<p class=\"$1\" id=\"$2\">$3</p>"],
-        "description": "HTML - Defines a paragraph",
-        "scope": "text.html"
+        "description": "Defines a paragraph"
     },
 "ul.": {
         "prefix": "ul.",
         "body": ["<ul class=\"$1\">", "\t$2", "</ul>"],
-        "description": "HTML - Defines an unordered list",
-        "scope": "text.html"
+        "description": "Defines an unordered list"
     },
 "ul#": {
         "prefix": "ul#",
         "body": ["<ul id=\"$1\">", "\t$2", "</ul>"],
-        "description": "HTML - Defines an unordered list",
-        "scope": "text.html"
+        "description": "Defines an unordered list"
     },
 "ul.#": {
         "prefix": "ul.#",
         "body": ["<ul class=\"$1\" id=\"$2\">", "\t$3", "</ul>"],
-        "description": "HTML - Defines an unordered list",
-        "scope": "text.html"
+        "description": "Defines an unordered list"
     },
 "ol.": {
         "prefix": "ol.",
         "body": ["<ol class=\"$1\">", "\t$2", "</ol>"],
-        "description": "HTML - Defines an ordered list",
-        "scope": "text.html"
+        "description": "Defines an ordered list"
     },
 "ol#": {
         "prefix": "ol#",
         "body": ["<ol id=\"$1\">", "\t$2", "</ol>"],
-        "description": "HTML - Defines an ordered list",
-        "scope": "text.html"
+        "description": "Defines an ordered list"
     },
 "ol.#": {
         "prefix": "ol.#",
         "body": ["<ol class=\"$1\" id=\"$2\">", "\t$3", "</ol>"],
-        "description": "HTML - Defines an ordered list",
-        "scope": "text.html"
+        "description": "Defines an ordered list"
     }
 }

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -111,6 +111,11 @@
         "body": "<caption>$1</caption>",
         "description": "Defines a table caption"
     },
+    "center": {
+        "prefix": "center",
+        "body": "<center>$1</center>",
+        "description": "Defines center-aligned text [DEPRECATED]"
+    },
     "cite": {
         "prefix": "cite",
         "body": "<cite>$1</cite>",
@@ -130,6 +135,11 @@
         "prefix": "colgroup",
         "body": ["<colgroup>", "\t$0", "</colgroup>"],
         "description": "Defines group of table columns"
+    },
+    "data": {
+        "prefix": "data",
+        "body": "<data value=\"$1\">$2</data>",
+        "description": "Defines a machine‑readable value for its content"
     },
     "datalist": {
         "prefix": "datalist",
@@ -200,6 +210,11 @@
         "prefix": "embed",
         "body": "<embed src=\"$1\" width=\"$2\" height=\"$3\">",
         "description": "Defines external interactive content or plugin"
+    },
+    "fencedframe": {
+        "prefix": "fencedframe",
+        "body": "<fencedframe width=\"$1\" height=\"$2\"></fencedframe>",
+        "description": "Defines an iframe with enhanced privacy [Limited support]"
     },
     "fieldset": {
         "prefix": "fieldset",
@@ -416,6 +431,11 @@
         "body": "<param name=\"$1\" value=\"$2\">",
         "description": "Defines a parameter for an object [DEPRECATED]"
     },
+    "picture": {
+        "prefix": "picture",
+        "body": ["<picture>", "\t$0", "</picture>"],
+        "description": "Defines a container for responsive images"
+    },
     "pre": {
         "prefix": "pre",
         "body": "<pre>$0</pre>",
@@ -430,6 +450,11 @@
         "prefix": "q",
         "body": "<q>$1</q>",
         "description": "Defines a short quotation"
+    },
+    "rb": {
+        "prefix": "rb",
+        "body": "<rb>$1</rb>",
+        "description": "Defines a base text element for ruby annotations [DEPRECATED]"
     },
     "rp": {
         "prefix": "rp",
@@ -461,6 +486,11 @@
         "body": "<script src=\"$1\"></script>",
         "description": "Defines a script or links to an external script"
     },
+    "search": {
+        "prefix": "search",
+        "body": ["<search>", "\t$0", "</search>"],
+        "description": "Defines a container for search/filter UI"
+    },
     "section": {
         "prefix": "section",
         "body": ["<section>", "\t$0", "</section>"],
@@ -470,6 +500,16 @@
         "prefix": "select",
         "body": ["<select name=\"$1\">", "\t$0", "</select>"],
         "description": "Defines a selectable list with options"
+    },
+    "selectedcontent": {
+        "prefix": "selectedcontent",
+        "body": "<selectedcontent></selectedcontent>",
+        "description": "Defines content representing the selected option in a <select> [Limited support]"
+    },
+    "slot": {
+        "prefix": "slot",
+        "body": "<slot name=\"$1\">$2</slot>",
+        "description": "Defines a placeholder inside a web component"
     },
     "small": {
         "prefix": "small",
@@ -530,6 +570,11 @@
         "prefix": "td",
         "body": "<td>$1</td>",
         "description": "Defines a table cell"
+    },
+    "template": {
+        "prefix": "template",
+        "body": ["<template>", "\t$1", "</template>"],
+        "description": "Defines a fragment of HTML for manipulation by script"
     },
     "textarea": {
         "prefix": "textarea",
@@ -599,5 +644,10 @@
             "</video>"
         ],
         "description": "Defines a video embed"
+    },
+    "wbr": {
+        "prefix": "wbr",
+        "body": "<wbr>",
+        "description": "Defines an optional word break opportunity"
     }
 }

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -188,7 +188,7 @@
     "dialog": {
         "prefix": "dialog",
         "body": "<dialog>$1</dialog>$2",
-        "description": "HTML - Defines a dialog (conversation)",
+        "description": "HTML - Defines a dialog box or modal window",
         "scope": "text.html"
     },
     "dfn": {
@@ -200,7 +200,7 @@
     "div": {
         "prefix": "div",
         "body": ["<div>", "\t$1", "</div>"],
-        "description": "HTML - Defines a section in a document",
+        "description": "HTML - Defines a generic block-level container",
         "scope": "text.html"
     },
     "dl": {
@@ -224,7 +224,7 @@
     "embed": {
         "prefix": "embed",
         "body": "<embed src=\"$1\">$2",
-        "description": "HTML - Defines external interactive content ot plugin",
+        "description": "HTML - Defines external interactive content or plugin",
         "scope": "text.html"
     },
     "fieldset": {
@@ -308,7 +308,7 @@
     "hgroup": {
         "prefix": "hgroup",
         "body": ["<hgroup>", "\t$1", "</hgroup>"],
-        "description": "HTML - Defines information about a section in a document",
+        "description": "HTML - Defines a heading grouped with subtitle or related text",
         "scope": "text.html"
     },
     "hr": {
@@ -351,7 +351,7 @@
     "iframe": {
         "prefix": "iframe",
         "body": "<iframe src=\"$1\">$2</iframe>$3",
-        "description": "HTML - Defines an inline sub window",
+        "description": "HTML - Defines a frame for embedding another document",
         "scope": "text.html"
     },
     "img": {
@@ -387,7 +387,7 @@
     "label": {
         "prefix": "label",
         "body": "<label for=\"$1\">$2</label>$3",
-        "description": "HTML - Defines an inline window",
+        "description": "HTML - Defines a label for a form element",
         "scope": "text.html"
     },
     "legend": {
@@ -411,7 +411,7 @@
     "main": {
         "prefix": "main",
         "body": ["<main>", "\t$1", "</main>"],
-        "description": "HTML - Defines an image map",
+        "description": "HTML - Defines the main content of the document",
         "scope": "text.html"
     },
     "map": {
@@ -585,7 +585,7 @@
     "span": {
         "prefix": "span",
         "body": "<span>$1</span>$2",
-        "description": "HTML - Defines a section in a document",
+        "description": "HTML - Defines a generic inline container",
         "scope": "text.html"
     },
     "strong": {
@@ -681,7 +681,7 @@
     "track": {
         "prefix": "track",
         "body": "<track src=\"$1\" kind=\"$2\" srclang=\"$3\" label=\"$4\">$5",
-        "description": "HTML - Defines a table row",
+        "description": "HTML - Defines text tracks for video or audio",
         "scope": "text.html"
     },
     "u": {
@@ -715,19 +715,19 @@
 "div.": {
         "prefix": "div.",
         "body": ["<div class=\"$1\">", "\t$2", "</div>"],
-        "description": "HTML - Defines a section in a document",
+        "description": "HTML - Defines a generic block-level container",
         "scope": "text.html"
     },
 "div#": {
         "prefix": "div#",
         "body": ["<div id=\"$1\">", "\t$2", "</div>"],
-        "description": "HTML - Defines a section in a document",
+        "description": "HTML - Defines a generic block-level container",
         "scope": "text.html"
     },
 "div.#": {
         "prefix": "div.#",
         "body": ["<div class=\"$1\" id=\"$2\">", "\t$3", "</div>"],
-        "description": "HTML - Defines a section in a document",
+        "description": "HTML - Defines a generic block-level container",
         "scope": "text.html"
     },
 "p.": {


### PR DESCRIPTION
Was wondering why the default snippets being suggested were so terrible, some even clearly had misinformation in them! Turns out the snippets were copied over from the [old VScode snippet extension](https://github.com/abusaidm/html-snippets/blob/master/snippets/snippets.json), which has been abandoned for at least 9 years as of today.

I've revised all html snippets and the placeholders inside their `body`. I also re-generated the poorly written descriptions with the help of an LLM (because that's what they excel at). Hope we're okay with that.