### PR TITLE
fix: fix snprintf arg template.

### DIFF
--- a/snippets/c/c.json
+++ b/snippets/c/c.json
@@ -299,7 +299,7 @@
     },
     "snprintf": {
         "prefix": "snprintf",
-        "body": ["snprintf(${1:buf}, ${2:max}, \"${3:%s}\\n\"$3);$0"],
+        "body": ["snprintf(${1:buf}, ${2:max}, \"${3:%s}\\n\"$4);$0"],
         "description": "snprintf() snippet"
     },
     "scanf": {


### PR DESCRIPTION
Origin snippet at c.json:300

```
    "snprintf": {
        "prefix": "snprintf",
        "body": ["snprintf(${1:buf}, ${2:max}, \"${3:%s}\\n\"$3);$0"],
        "description": "snprintf() snippet"
    },
```

When i use this snippet , it will fill like this.

![snprintf_report](https://github.com/user-attachments/assets/8973af78-4e37-40f7-b7ae-bddfe0aca736)

Fix it by replace the second $3 to $4