### PR TITLE
Adds Bevy game engine snippets (v0.18 compatible)

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,10 @@
             },
             {
                 "language": "rust",
+                "path": "./snippets/frameworks/bevy.json"
+            },
+            {
+                "language": "rust",
                 "path": "./snippets/frameworks/relm4/workers.json"
             },
             {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
                 "path": "./snippets/rust/rustdoc.json"
             },
             {
-                "language": "rust",
+                "language": "bevy",
                 "path": "./snippets/frameworks/bevy.json"
             },
             {

--- a/package.json
+++ b/package.json
@@ -153,10 +153,6 @@
                 "path": "./snippets/rust/rustdoc.json"
             },
             {
-                "language": "bevy",
-                "path": "./snippets/frameworks/bevy.json"
-            },
-            {
                 "language": "rust",
                 "path": "./snippets/frameworks/relm4/workers.json"
             },
@@ -504,6 +500,10 @@
             {
                 "language": "objc",
                 "path": "./snippets/objc.json"
+            },
+            {
+                "language": "bevy",
+                "path": "./snippets/frameworks/bevy.json"
             },
             {
                 "language": "unreal",

--- a/snippets/frameworks/bevy.json
+++ b/snippets/frameworks/bevy.json
@@ -97,7 +97,7 @@
     "Bevy Observer": {
         "prefix": "observer",
         "body": [
-            "fn ${1:on_add}(trigger: On<Add, ${2:MyComponent}>, mut commands: Commands) {",
+            "fn ${1:my_observer}(trigger: On<${2:Add}, ${3:MyComponent}>, mut commands: Commands) {",
             "\t$0",
             "}"
         ],

--- a/snippets/frameworks/bevy.json
+++ b/snippets/frameworks/bevy.json
@@ -29,8 +29,8 @@
     },
     "Bevy Resource": {
         "prefix": "resource",
-        "body": ["#[derive(Resource)]", "pub struct ${1:MyResource} {", "\t$0", "}"],
-        "description": "Bevy Resource struct"
+        "body": ["#[derive(Resource)]", "pub struct ${1:MyResource}($0);"],
+        "description": "Bevy Resource tuple"
     },
     "Bevy Event": {
         "prefix": "event",
@@ -39,7 +39,7 @@
     },
     "Bevy Bundle": {
         "prefix": "bundle",
-        "body": ["#[derive(Bundle)]", "pub struct ${1:MyBundle} {", "\t$0", "}"],
+        "body": ["#[derive(Bundle)]", "pub struct ${1:MyBundle} {$0}"],
         "description": "Bevy Bundle struct"
     },
     "Bevy State": {

--- a/snippets/frameworks/bevy.json
+++ b/snippets/frameworks/bevy.json
@@ -1,6 +1,6 @@
 {
     "Bevy Prelude": {
-        "prefix": "prelude",
+        "prefix": "bevy",
         "body": "use bevy::prelude::*;",
         "description": "Import Bevy prelude"
     },

--- a/snippets/frameworks/bevy.json
+++ b/snippets/frameworks/bevy.json
@@ -80,17 +80,17 @@
         "description": "Bevy Res system parameter"
     },
     "Bevy ResMut param": {
-        "prefix": "res mut",
+        "prefix": "resmut",
         "body": "mut ${1:name}: ResMut<${2}>",
         "description": "Bevy ResMut system parameter"
     },
     "Bevy EventWriter param": {
-        "prefix": "event writer",
+        "prefix": "eventwriter",
         "body": "mut ${1:events}: EventWriter<${2}>",
         "description": "Bevy EventWriter system parameter"
     },
     "Bevy EventReader param": {
-        "prefix": "event reader",
+        "prefix": "eventreader",
         "body": "mut ${1:events}: EventReader<${2}>",
         "description": "Bevy EventReader system parameter"
     },
@@ -102,5 +102,10 @@
             "}"
         ],
         "description": "Bevy Observer system"
+    },
+    "Bevy System": {
+        "prefix": "system",
+        "body": ["fn ${1:my_system}(${2:args}) {", "\t$0", "}"],
+        "description": "Bevy System function"
     }
 }

--- a/snippets/frameworks/bevy.json
+++ b/snippets/frameworks/bevy.json
@@ -1,0 +1,106 @@
+{
+    "Bevy Prelude": {
+        "prefix": "prelude",
+        "body": "use bevy::prelude::*;",
+        "description": "Import Bevy prelude"
+    },
+    "Bevy Plugin (struct)": {
+        "prefix": "plugin",
+        "body": [
+            "pub struct ${1:MyPlugin};",
+            "",
+            "impl Plugin for ${1:MyPlugin} {",
+            "\tfn build(&self, app: &mut App) {",
+            "\t\t$0",
+            "\t}",
+            "}"
+        ],
+        "description": "Bevy Plugin struct with impl"
+    },
+    "Bevy Plugin (fn)": {
+        "prefix": "plugin",
+        "body": ["fn ${1:my_plugin}(app: &mut App) {", "\t$0", "}"],
+        "description": "Bevy Plugin as a function"
+    },
+    "Bevy Component": {
+        "prefix": "component",
+        "body": ["#[derive(Component)]", "pub struct ${1:MyComponent};"],
+        "description": "Bevy Component unit struct"
+    },
+    "Bevy Resource": {
+        "prefix": "resource",
+        "body": ["#[derive(Resource)]", "pub struct ${1:MyResource} {", "\t$0", "}"],
+        "description": "Bevy Resource struct"
+    },
+    "Bevy Event": {
+        "prefix": "event",
+        "body": ["#[derive(Event)]", "pub struct ${1:MyEvent};"],
+        "description": "Bevy Event struct"
+    },
+    "Bevy Bundle": {
+        "prefix": "bundle",
+        "body": ["#[derive(Bundle)]", "pub struct ${1:MyBundle} {", "\t$0", "}"],
+        "description": "Bevy Bundle struct"
+    },
+    "Bevy State": {
+        "prefix": "state",
+        "body": [
+            "#[derive(States, Default, Clone, Copy, PartialEq, Eq, Hash, Debug)]",
+            "pub enum ${1:MyState} {",
+            "\t#[default]",
+            "\t${2:InitialState},",
+            "\t$0",
+            "}"
+        ],
+        "description": "Bevy States enum"
+    },
+    "Bevy SystemSet": {
+        "prefix": "systemset",
+        "body": [
+            "#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]",
+            "pub enum ${1:MySet} {",
+            "\t$0",
+            "}"
+        ],
+        "description": "Bevy SystemSet enum"
+    },
+    "Bevy Query param": {
+        "prefix": "query",
+        "body": "${1:query}: Query<${2}>",
+        "description": "Bevy Query system parameter"
+    },
+    "Bevy Commands param": {
+        "prefix": "commands",
+        "body": "mut commands: Commands",
+        "description": "Bevy Commands system parameter"
+    },
+    "Bevy Res param": {
+        "prefix": "res",
+        "body": "${1:name}: Res<${2}>",
+        "description": "Bevy Res system parameter"
+    },
+    "Bevy ResMut param": {
+        "prefix": "res mut",
+        "body": "mut ${1:name}: ResMut<${2}>",
+        "description": "Bevy ResMut system parameter"
+    },
+    "Bevy EventWriter param": {
+        "prefix": "event writer",
+        "body": "mut ${1:events}: EventWriter<${2}>",
+        "description": "Bevy EventWriter system parameter"
+    },
+    "Bevy EventReader param": {
+        "prefix": "event reader",
+        "body": "mut ${1:events}: EventReader<${2}>",
+        "description": "Bevy EventReader system parameter"
+    },
+    "Bevy Observer": {
+        "prefix": "observer",
+        "body": [
+            "fn ${1:on_add}(trigger: On<Add, ${2:MyComponent}>, mut commands: Commands) {",
+            "\t$0",
+            "}"
+        ],
+        "description": "Bevy Observer system"
+    }
+}


### PR DESCRIPTION
Added some snippets for initialising common constructs in current version of [Bevy](https://bevy.org/learn/quick-start/getting-started/ecs/).

Adds top-level stuff:
- `bevy` -> use prelude (useful in almost every file)
- `plugin` -> function and struct plugin declaration
- `component` -> component declaration
- `resource` -> resource struct declaration
- `event` -> event struct declaration
- `state` -> state enum declaration
- `systemset` -> systemset enum declaration
- `system` -> plain system function
- `observer` -> observer function

And system-level stuff:
- `query` -> system `Query<..>` query argument
- `commands` -> world Commands argument
- `res` -> Read-only resource argument
- `resmut` -> Mutable resource argument
- `eventreader` -> EventReader argument
- `eventwriter` -> EventWriter arugment