### PR TITLE
fix(lua.json): make ll value editable

### DIFF
--- a/snippets/lua/lua.json
+++ b/snippets/lua/lua.json
@@ -11,7 +11,7 @@
     },
     "assigment": {
         "prefix": "ll",
-        "body": ["local ${1:varName} = ${0:value}"],
+        "body": ["local ${1:varName} = ${2:value}"],
         "description": "Define a variable"
     },
     "local": {


### PR DESCRIPTION
This PR fixes a bug in lua.json when using blink-cmp. 

The ll snippet for lua wasn't working correctly. 
Changing the _**varName**_ placeholder worked but pressing **Tab** then **unselected** the _**value**_ placeholder and you had to delete it manually instead of just typing.


https://github.com/user-attachments/assets/0d385045-ef58-40f7-898f-6ccd877fa914

The PR works with people using nvim-cmp, I tested that myself.