### PR TITLE
fix: remove redundant filetype mappings causing duplicate completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
         "snippets": [
             {
                 "language": [
-                    "plaintext",
-                    "markdown",
-                    "tex",
-                    "html",
                     "global",
                     "all"
                 ],


### PR DESCRIPTION
## Problem

`global.json` is mapped to both `"all"` (global) and specific filetypes (`"plaintext"`, `"markdown"`, `"tex"`, `"html"`) in `package.json`:

```json
"language": ["plaintext", "markdown", "tex", "html", "global", "all"]
```

In snippet engines (both blink.cmp's default preset and LuaSnip's vscode loader), global snippets and filetype-specific snippets are loaded separately. This causes `global.json` to be loaded **twice** for these four filetypes — once via the `"all"` key (global pass) and once via the filetype-specific key (ft-specific pass). The two loads produce identical completion items that are concatenated without deduplication, resulting in every snippet from `global.json` appearing twice in the completion menu.

Affected snippets include: `date`, `datetime`, `diso`, `time`, `timeHMS`, `dateDMY`, `dateMDY`, `copyright` — duplicated for markdown, plaintext, tex, and html.

## Fix

Remove `"plaintext"`, `"markdown"`, `"tex"`, `"html"` from `global.json`'s language list, keeping only `"global"` and `"all"`. The `"all"` key already ensures global availability across all filetypes.

```json
"language": ["global", "all"]
```

## Verification

- No functionality is lost: `"all"` covers every filetype including the removed ones
- `"global"` is retained for backwards compatibility with engines that may use it
- Other snippet files (e.g., `markdown.json`) are unaffected — they continue to load for their respective filetypes only